### PR TITLE
Refactor paint_solid to iterate over the pixel list

### DIFF
--- a/lib/xebow/rgb_matrix.ex
+++ b/lib/xebow/rgb_matrix.ex
@@ -109,7 +109,7 @@ defmodule Xebow.RGBMatrix do
 
   defp paint_solid(spidev, color) do
     color = Chameleon.Keyword.new(color)
-    colors = for _ <- 1..12, do: color
+    colors = Enum.map(@pixels, fn _ -> color end)
     paint(spidev, colors)
   end
 


### PR DESCRIPTION
Just a small change to iterate over the list of pixels in `@pixels` in case it changes for some reason, rather than relying on the hard-coded range `1..12`. Although the list is probably unlikely to change, at least this way if it does it won't introduce a bug in this part of the code.