### PR TITLE
Fix the upload script to reflect the correct target and destination

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -48,8 +48,8 @@ help() {
     exit 1
 }
 
-[ -n "$DESTINATION" ] || DESTINATION=nerves.local
-[ -n "$MIX_TARGET" ] || MIX_TARGET=rpi0
+[ -n "$DESTINATION" ] || DESTINATION=xebow.local
+[ -n "$MIX_TARGET" ] || MIX_TARGET=kebow
 [ -n "$MIX_ENV" ] || MIX_ENV=dev
 if [ -z "$FILENAME" ]; then
     FIRMWARE_PATH="./_build/${MIX_TARGET}_${MIX_ENV}/nerves/images"


### PR DESCRIPTION
This PR fixes a bug introduced after some of the renaming changes, where `./upload.sh` would fail to find the firmware file and target unless these arguments were explicitly passed to the script. This fixes the default values.