### PR TITLE
Update Chameleon version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,10 +58,7 @@ defmodule Xebow.MixProject do
       {:shoehorn, "~> 0.6"},
       {:ring_logger, "~> 0.8"},
       {:toolshed, "~> 0.2"},
-      # {:chameleon, "~> 2.2"},
-      # Open upstream PR:
-      # https://github.com/supersimple/chameleon/pull/18
-      {:chameleon, github: "amclain/chameleon", ref: "update-spec-for-new"},
+      {:chameleon, github: "supersimple/chameleon", ref: "19a8b0a"},
       {:afk, "~> 0.3"},
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},
       {:ex_doc, "~> 0.21.3", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "afk": {:hex, :afk, "0.3.0", "87ca8a98bdb6f5da3fdf96fc091c67655b15d593df38fb191d6324b05488172f", [:mix], [], "hexpm", "f7a1609a6a45221fcf11d5c531046d632e11368a4674c13ee7453e3fb0cc67a8"},
-  "chameleon": {:git, "https://github.com/amclain/chameleon.git", "ceadb84dd5a7c0102cbad98c6fe4e1f44975e190", [ref: "update-spec-for-new"]},
+  "chameleon": {:git, "https://github.com/supersimple/chameleon.git", "19a8b0a8c0d818c336748972221f29249b14d6e3", [ref: "19a8b0a"]},
   "circuits_gpio": {:hex, :circuits_gpio, "0.4.5", "4d5b0f707c425fc56f03086232259f65482a3d1f1cf15335253636d0bb846446", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "b42d28d60a6cfdfb6b21b66ab0b8c5de0ea5a32b390b61d2fe86a2ad8edb90ad"},
   "circuits_spi": {:hex, :circuits_spi, "0.1.5", "5f1901c77fb982217a956498ba0d9d0d47cc58ec47731020621b5c95eee296c0", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "134e1ded8e0379e3314a507e80a304cf5ba54edf294e157b7e7ecedcdca30dfd"},
   "cowboy": {:hex, :cowboy, "2.7.0", "91ed100138a764355f43316b1d23d7ff6bdb0de4ea618cb5d8677c93a7a2f115", [:rebar3], [{:cowlib, "~> 2.8.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "04fd8c6a39edc6aaa9c26123009200fc61f92a3a94f3178c527b70b767c6e605"},


### PR DESCRIPTION
Related: #12 / 07654b6
Related: supersimple/chameleon#18

This PR updates the Chameleon dependency off of the bug fix fork and back to the original repo now that the upstream PR has been merged.