### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 on:
   - push
+  - pull_request
 
 jobs:
   code_formatting:


### PR DESCRIPTION
Resolves #27 

This PR resolves the issue of CI not running when someone forks the repo and submits a PR. Although the diff of this PR may seem obvious, there are some nuances that I tested out in another repo. On `push`, CI is run when commits are pushed to the source repo, but _not_ when they are pushed to a forked repo, even if the forked repo includes the GitHub Actions CI config file. On `pull_request` CI is run when a PR is opened from either the source repo or a fork, and is also run every time a commit is pushed to the PR branch. However, it does _not_ run when the PR is merged to `master`, which means behavioral merge conflicts could occur during this process and not be caught when the merge to `master` happens.

So there is one catch to enabling CI on both `push` and `pull_request`: Repo maintainers who push a branch to the source repo will have CI trigger at that point, as well as when opening a PR. This double-run counts against the GitHub Actions runtime limit, which is why I was initially trying to avoid it. However, this repo isn't active enough yet for it to be an issue and I think we want to create a more favorable experience for people forking the repo. Since the repo exists under the `ElixirSeattle` org, maintainers may be able to get around the double-run by forking the repo if it becomes an issue. So this PR is enabling CI runs on `pull_request` in addition to `push`.