### PR TITLE
Refactor: Separate the render engine from the hardware

### DIFF
--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -36,6 +36,7 @@ defmodule Xebow.Application do
       # {Xebow.Worker, arg},
       Xebow.HIDGadget,
       Xebow.RGBMatrix,
+      {Xebow.Engine, {Xebow.RGBMatrix}},
       Xebow.Keys
     ]
   end

--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -36,7 +36,7 @@ defmodule Xebow.Application do
       # {Xebow.Worker, arg},
       Xebow.HIDGadget,
       Xebow.RGBMatrix,
-      {Xebow.Engine, {Xebow.RGBMatrix}},
+      {Xebow.Engine, [Xebow.RGBMatrix]},
       Xebow.Keys
     ]
   end

--- a/lib/xebow/engine.ex
+++ b/lib/xebow/engine.ex
@@ -21,8 +21,7 @@ defmodule Xebow.Engine do
   Start the engine.
 
   This function accepts a tuple that contains the following arguments:
-  - `paintable_module` - A module that implements `get_paint_fn`, which
-    returns an anonymous function that accepts a frame to paint.
+  - `paintable_module` - A module that implements the `Xebow.Paintable` behaviour.
   """
   @spec start_link({paintable_module :: module}) :: GenServer.on_start()
   def start_link({paintable_module}) do

--- a/lib/xebow/engine.ex
+++ b/lib/xebow/engine.ex
@@ -1,0 +1,159 @@
+defmodule Xebow.Engine do
+  @moduledoc """
+  Renders [`Animation`](`Xebow.Animation`)s and outputs
+  [`Frame`](`Xebow.Frame`)s to be displayed.
+  """
+
+  use GenServer
+
+  import Xebow.Utils, only: [mod: 2]
+
+  alias Xebow.Animation
+
+  defmodule State do
+    @moduledoc false
+    defstruct [:animation, :paint_fn]
+  end
+
+  # Client
+
+  @doc """
+  Start the engine.
+
+  This function accepts a tuple that contains the following arguments:
+  - `paintable_module` - A module that implements `get_paint_fn`, which
+    returns an anonymous function that accepts a frame to paint.
+  """
+  @spec start_link({paintable_module :: module}) :: GenServer.on_start()
+  def start_link({paintable_module}) do
+    paint_fn = paintable_module.get_paint_fn
+    GenServer.start_link(__MODULE__, {paint_fn}, name: __MODULE__)
+  end
+
+  @doc """
+  Cycle to the next animation and play it.
+  """
+  @spec next_animation :: :ok
+  def next_animation do
+    GenServer.cast(__MODULE__, :next_animation)
+  end
+
+  @doc """
+  Cycle to the previous animation and play it.
+  """
+  @spec previous_animation :: :ok
+  def previous_animation do
+    GenServer.cast(__MODULE__, :previous_animation)
+  end
+
+  @doc """
+  Play the given animation.
+
+  Note that the animation can be played synchronously by passing `:false` for the `:async` option. However, only
+  looping (animations with `:loop` >= 1) animations may be played this way. This is to ensure that the caller is not
+  blocked forever.
+  """
+  @spec play_animation(animation :: Animation.t(), opts :: keyword()) :: :ok
+  def play_animation(animation, opts \\ []) do
+    async? = Keyword.get(opts, :async, true)
+
+    if async? do
+      GenServer.cast(__MODULE__, {:play_animation, animation})
+    else
+      GenServer.call(__MODULE__, {:play_animation, animation})
+    end
+  end
+
+  # Server
+
+  @impl GenServer
+  def init({paint_fn}) do
+    send(self(), :get_next_frame)
+
+    [initial_animation_type | _] = Animation.types()
+    animation = Animation.new(type: initial_animation_type)
+
+    state =
+      %State{paint_fn: paint_fn}
+      |> set_animation(animation)
+
+    {:ok, state}
+  end
+
+  defp set_animation(state, animation) do
+    %State{state | animation: animation}
+  end
+
+  @impl GenServer
+  def handle_info(:get_next_frame, state) do
+    animation = Animation.next_frame(state.animation)
+    state.paint_fn.(animation.next_frame)
+
+    Process.send_after(self(), :get_next_frame, animation.delay_ms)
+    {:noreply, set_animation(state, animation)}
+  end
+
+  @impl GenServer
+  def handle_info({:reset_animation, reset_animation}, state) do
+    {:noreply, set_animation(state, reset_animation)}
+  end
+
+  @impl GenServer
+  def handle_info({:reply, from, reset_animation}, state) do
+    GenServer.reply(from, :ok)
+
+    {:noreply, set_animation(state, reset_animation)}
+  end
+
+  @impl GenServer
+  def handle_cast(:next_animation, state) do
+    animation_types = Animation.types()
+    num = Enum.count(animation_types)
+    current = Enum.find_index(animation_types, &(&1 == state.animation.type))
+    next = mod(current + 1, num)
+    animation_type = Enum.at(animation_types, next)
+    animation = Animation.new(type: animation_type)
+
+    {:noreply, set_animation(state, animation)}
+  end
+
+  @impl GenServer
+  def handle_cast(:previous_animation, state) do
+    animation_types = Animation.types()
+    num = Enum.count(animation_types)
+    current = Enum.find_index(animation_types, &(&1 == state.animation.type))
+    previous = mod(current - 1, num)
+    animation_type = Enum.at(animation_types, previous)
+    animation = Animation.new(type: animation_type)
+
+    {:noreply, set_animation(state, animation)}
+  end
+
+  @impl GenServer
+  def handle_cast({:play_animation, %{loop: loop} = animation}, state) when loop >= 1 do
+    current_animation = state.animation
+    expected_duration = Animation.duration(animation)
+    Process.send_after(self(), {:reset_animation, current_animation}, expected_duration)
+
+    {:noreply, set_animation(state, animation)}
+  end
+
+  @impl GenServer
+  def handle_cast({:play_animation, %{loop: 0} = _animation}, state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:play_animation, animation}, state) do
+    {:noreply, set_animation(state, animation)}
+  end
+
+  @impl GenServer
+  def handle_call({:play_animation, %{loop: loop} = animation}, from, state) when loop >= 1 do
+    current_animation = state.animation
+    duration = Animation.duration(animation)
+    Process.send_after(self(), {:reply, from, current_animation}, duration)
+
+    {:noreply, set_animation(state, animation)}
+  end
+end

--- a/lib/xebow/frame.ex
+++ b/lib/xebow/frame.ex
@@ -6,9 +6,9 @@ defmodule Xebow.Frame do
   list of frames or each frame can be dynamically generated based on the tick of some animation.
   """
 
-  alias Xebow.RGBMatrix
+  alias Xebow.Pixel
 
-  @type pixel_map :: %{required(RGBMatrix.pixel()) => RGBMatrix.pixel_color()}
+  @type pixel_map :: %{required(Pixel.t()) => Pixel.color()}
 
   @type t :: %__MODULE__{
           pixel_map: pixel_map()
@@ -16,7 +16,7 @@ defmodule Xebow.Frame do
 
   defstruct [:pixel_map]
 
-  @spec new(pixels :: list(RGBMatrix.pixel()), pixel_colors :: list(RGBMatrix.pixel_color())) ::
+  @spec new(pixels :: list(Pixel.t()), pixel_colors :: list(Pixel.color())) ::
           t()
   def new(pixels, pixel_colors) do
     pixel_map =
@@ -26,7 +26,7 @@ defmodule Xebow.Frame do
     %__MODULE__{pixel_map: pixel_map}
   end
 
-  @spec solid_color(pixels :: list(RGBMatrix.pixel()), color :: RGBMatrix.pixel_color()) :: t()
+  @spec solid_color(pixels :: list(Pixel.t()), color :: Pixel.color()) :: t()
   def solid_color(pixels, color) do
     pixel_colors = List.duplicate(color, length(pixels))
     new(pixels, pixel_colors)

--- a/lib/xebow/keys.ex
+++ b/lib/xebow/keys.ex
@@ -164,15 +164,15 @@ defmodule Xebow.Keys do
 
     animation = Animation.new(type: Animation.Static, frames: [frame], delay_ms: 250, loop: 1)
 
-    Xebow.RGBMatrix.play_animation(animation, async: false)
+    Xebow.Engine.play_animation(animation, async: false)
   end
 
   def next_animation do
-    Xebow.RGBMatrix.next_animation()
+    Xebow.Engine.next_animation()
   end
 
   def previous_animation do
-    Xebow.RGBMatrix.previous_animation()
+    Xebow.Engine.previous_animation()
   end
 
   def start_wifi_wizard do

--- a/lib/xebow/paintable.ex
+++ b/lib/xebow/paintable.ex
@@ -1,0 +1,14 @@
+defmodule Xebow.Paintable do
+  @moduledoc """
+  A paintable module controls physical pixels.
+  """
+
+  @doc """
+  Returns a function that can be called to paint the pixels for a given frame.
+  The anonymous function's return value is unused.
+
+  This callback makes any hardware implementation details opaque to the caller,
+  while allowing the paintable to retain control of the physical pixels.
+  """
+  @callback get_paint_fn :: (frame :: Xebow.Frame.t() -> any)
+end

--- a/lib/xebow/pixel.ex
+++ b/lib/xebow/pixel.ex
@@ -1,0 +1,27 @@
+defmodule Xebow.Pixel do
+  @moduledoc """
+  A pixel is a unit that has X and Y coordinates and displays a single color.
+  """
+
+  @typedoc """
+  A tuple containing the X and Y coordinates of the pixel.
+  """
+  @type t :: {x :: non_neg_integer, y :: non_neg_integer}
+
+  @typedoc """
+  The color of the pixel, represented as a `Chameleon.Color` color model.
+  """
+  @type color :: any_color_model
+
+  @typedoc """
+  Shorthand for any `Chameleon.Color` color model.
+  """
+  @type any_color_model ::
+          Chameleon.Color.RGB.t()
+          | Chameleon.Color.CMYK.t()
+          | Chameleon.Color.Hex.t()
+          | Chameleon.Color.HSL.t()
+          | Chameleon.Color.HSV.t()
+          | Chameleon.Color.Keyword.t()
+          | Chameleon.Color.Pantone.t()
+end

--- a/lib/xebow/rgb_matrix.ex
+++ b/lib/xebow/rgb_matrix.ex
@@ -10,18 +10,6 @@ defmodule Xebow.RGBMatrix do
     defstruct [:spidev]
   end
 
-  @type any_color_model ::
-          Chameleon.Color.RGB.t()
-          | Chameleon.Color.CMYK.t()
-          | Chameleon.Color.Hex.t()
-          | Chameleon.Color.HSL.t()
-          | Chameleon.Color.HSV.t()
-          | Chameleon.Color.Keyword.t()
-          | Chameleon.Color.Pantone.t()
-
-  @type pixel :: {non_neg_integer, non_neg_integer}
-  @type pixel_color :: any_color_model
-
   @spi_device "spidev0.0"
   @spi_speed_hz 4_000_000
   @sof <<0, 0, 0, 0>>
@@ -32,7 +20,6 @@ defmodule Xebow.RGBMatrix do
   def start_link([]) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
-
 
   @impl Xebow.Paintable
   def get_paint_fn do

--- a/lib/xebow/rgb_matrix.ex
+++ b/lib/xebow/rgb_matrix.ex
@@ -1,4 +1,6 @@
 defmodule Xebow.RGBMatrix do
+  @behaviour Xebow.Paintable
+
   use GenServer
 
   alias Circuits.SPI
@@ -31,10 +33,8 @@ defmodule Xebow.RGBMatrix do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  @doc """
-  Returns a function that can be called to paint the pixels.
-  """
-  @spec get_paint_fn :: (Xebow.Frame.t() -> any)
+
+  @impl Xebow.Paintable
   def get_paint_fn do
     GenServer.call(__MODULE__, :get_paint_fn)
   end

--- a/lib/xebow/utils.ex
+++ b/lib/xebow/utils.ex
@@ -37,6 +37,6 @@ defmodule Xebow.Utils do
     {2, 3}
   ]
 
-  @spec pixels() :: list(Xebow.RGBMatrix.pixel())
+  @spec pixels() :: list(Xebow.Pixel.t())
   def pixels, do: @pixels
 end


### PR DESCRIPTION
This PR is inspired by the [2020-06-02 meeting notes](https://github.com/ElixirSeattle/xebow/wiki/Meeting-Notes-%282020-06-02%29), and separates out a render `Engine` from the `RGBMatrix`. This shifts the responsibility of animation drawing and frame timing to `Engine`; the engine now producing a frame to be painted and requesting it be painted at the appropriate time. `RGBMatrix` has been refactored to focus on control of the hardware pixels, and it is responsible for managing the SPI bus.

`Paintable` has been introduced as a behaviour that is implemented by hardware that wants to expose pixels. It allows a module to wrap the pixel control logic into an anonymous function that accepts a `Frame`. `Engine` can then use this anonymous function from a `Paintable` to be able to push frames to the hardware with the appropriate timing without being exposed to the hardware implementation details.

![Xebow2](https://user-images.githubusercontent.com/4755047/85182037-5d38b200-b23c-11ea-9050-8f8db14b5a27.png)

-----

@doughsay this PR should hopefully make the LiveView spike you're working on easier, as you could make your view a `Paintable` and not have to worry about reimplementing the engine to work in a web app.