### PR TITLE
Add missing backtick to the Animation docs

### DIFF
--- a/lib/xebow/animation.ex
+++ b/lib/xebow/animation.ex
@@ -9,7 +9,7 @@ defmodule Xebow.Animation do
   examples.
 
   Alternatively, you may have a more dynamic animation which generates frames based on the current `:tick` of the
-  animation. See `Xebow.Animation.{CycleAll, CycleLeftToRight, Pinwheel} for examples.
+  animation. See `Xebow.Animation.{CycleAll, CycleLeftToRight, Pinwheel}` for examples.
   """
 
   alias __MODULE__


### PR DESCRIPTION
This PR fixes the following warning when generating the docs:

```text
warning: ExDoc.Markdown.Earmark (warning) lib/xebow/animation.ex:12
Closing unclosed backquotes ` at end of input
```