### PR TITLE
Set the docs mix task to use the keybow environment

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,12 @@ defmodule Xebow.MixProject do
       deps: deps(),
       docs: [extras: ["README.md"]],
       releases: [{@app, release()}],
-      preferred_cli_target: [run: :host, test: :host, dialyzer: :keybow],
+      preferred_cli_target: [
+        run: :host,
+        test: :host,
+        dialyzer: :keybow,
+        docs: :keybow
+      ],
       dialyzer: [
         ignore_warnings: "dialyzer.ignore.exs",
         list_unused_filters: true,


### PR DESCRIPTION
A small PR that
1. Fixes all the warnings from the target hardware libraries (like Circuits) not being available and
2. Adds hyperlinks and the popup box to any of these external modules we may need to reference, like shown below

![image](https://user-images.githubusercontent.com/4755047/85508367-c6a42200-b5a8-11ea-89e6-5951bac4547b.png)

(This is an illustration; this link is not in the real docs for this module.)