### PR TITLE
Set mix target to keybow when building firmware

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Xebow.MixProject do
         run: :host,
         test: :host,
         dialyzer: :keybow,
-        docs: :keybow
+        docs: :keybow,
+        firmware: :keybow
       ],
       dialyzer: [
         ignore_warnings: "dialyzer.ignore.exs",


### PR DESCRIPTION
Obviates the need to export MIX_TARGET when building the firmware.