### PR TITLE
Moves the RGBMatrix concerns out of Xebow.

### DIFF
--- a/lib/rgb_matrix/animation.ex
+++ b/lib/rgb_matrix/animation.ex
@@ -1,23 +1,23 @@
-defmodule Xebow.Animation do
+defmodule RGBMatrix.Animation do
   @moduledoc """
-  Provides a data structure and functions to define a Xebow animation.
+  Provides a data structure and functions to define an RGBMatrix animation.
 
   There are currently two distinct ways to define an animation.
 
   You may define an animation with a predefined `:frames` field. Each frame will advance every `:delay_ms` milliseconds.
-  These animations should use the `Xebow.Animation.Static` `:type`. See the moduledocs of that module for
+  These animations should use the `RGBMatrix.Animation.Static` `:type`. See the moduledocs of that module for
   examples.
 
   Alternatively, you may have a more dynamic animation which generates frames based on the current `:tick` of the
-  animation. See `Xebow.Animation.{CycleAll, CycleLeftToRight, Pinwheel}` for examples.
+  animation. See `RGBMatrix.Animation.{CycleAll, CycleLeftToRight, Pinwheel}` for examples.
   """
 
   alias __MODULE__
-  alias Xebow.Frame
+  alias RGBMatrix.Frame
 
   defmacro __using__(_) do
     quote do
-      alias Xebow.Animation
+      alias RGBMatrix.Animation
 
       @behaviour Animation
     end

--- a/lib/rgb_matrix/animation/cycle_all.ex
+++ b/lib/rgb_matrix/animation/cycle_all.ex
@@ -1,13 +1,13 @@
-defmodule Xebow.Animation.CycleAll do
+defmodule RGBMatrix.Animation.CycleAll do
   @moduledoc """
   Cycles hue of all keys.
   """
 
   alias Chameleon.HSV
 
-  alias Xebow.{Animation, Frame}
+  alias RGBMatrix.{Animation, Frame}
 
-  import Xebow.Utils, only: [mod: 2]
+  import RGBMatrix.Utils, only: [mod: 2]
 
   use Animation
 
@@ -19,6 +19,7 @@ defmodule Xebow.Animation.CycleAll do
     hue = mod(time, 360)
     color = HSV.new(hue, 100, 100)
 
+    # FIXME: no reaching into Xebow namespace
     pixels = Xebow.Utils.pixels()
     pixel_colors = Enum.map(pixels, fn {_x, _y} -> color end)
 

--- a/lib/rgb_matrix/animation/cycle_left_to_right.ex
+++ b/lib/rgb_matrix/animation/cycle_left_to_right.ex
@@ -1,13 +1,13 @@
-defmodule Xebow.Animation.CycleLeftToRight do
+defmodule RGBMatrix.Animation.CycleLeftToRight do
   @moduledoc """
   Cycles hue left to right.
   """
 
   alias Chameleon.HSV
 
-  alias Xebow.{Animation, Frame}
+  alias RGBMatrix.{Animation, Frame}
 
-  import Xebow.Utils, only: [mod: 2]
+  import RGBMatrix.Utils, only: [mod: 2]
 
   use Animation
 
@@ -16,6 +16,7 @@ defmodule Xebow.Animation.CycleLeftToRight do
     %Animation{tick: tick, speed: speed} = animation
     time = div(tick * speed, 100)
 
+    # FIXME: no reaching into Xebow namespace
     pixels = Xebow.Utils.pixels()
 
     pixel_colors =

--- a/lib/rgb_matrix/animation/pinwheel.ex
+++ b/lib/rgb_matrix/animation/pinwheel.ex
@@ -1,13 +1,13 @@
-defmodule Xebow.Animation.Pinwheel do
+defmodule RGBMatrix.Animation.Pinwheel do
   @moduledoc """
   Cycles hue in a pinwheel pattern.
   """
 
   alias Chameleon.HSV
 
-  alias Xebow.{Animation, Frame}
+  alias RGBMatrix.{Animation, Frame}
 
-  import Xebow.Utils, only: [mod: 2]
+  import RGBMatrix.Utils, only: [mod: 2]
 
   use Animation
 
@@ -21,6 +21,7 @@ defmodule Xebow.Animation.Pinwheel do
     %Animation{tick: tick, speed: speed} = animation
     time = div(tick * speed, 100)
 
+    # FIXME: no reaching into Xebow namespace
     pixels = Xebow.Utils.pixels()
 
     pixel_colors =

--- a/lib/rgb_matrix/animation/static.ex
+++ b/lib/rgb_matrix/animation/static.ex
@@ -1,13 +1,13 @@
-defmodule Xebow.Animation.Static do
+defmodule RGBMatrix.Animation.Static do
   @moduledoc """
   Pre-defined animations that run as a one-shot or on a loop.
 
-  The `Xebow.Animation.Static` animation type is used to define animations with a pre-defined set of frames. These
+  The `RGBMatrix.Animation.Static` animation type is used to define animations with a pre-defined set of frames. These
   animations can be played continiously or on a loop. This behavior is controlled by the `:loop` field on the animation.
   A value of `:infinite` means to play the animation continuously, while a value greater than 0 means to loop the animation
   `:loop` times.
 
-  Note that the playback speed of these animations is controlled by the `:delay_ms` field in the animation struct. The 
+  Note that the playback speed of these animations is controlled by the `:delay_ms` field in the animation struct. The
   `:speed` field not used when rendering these animations.
 
   ## Examples
@@ -20,25 +20,25 @@ defmodule Xebow.Animation.Static do
     end)
   end
 
-  generator = fn -> struct!(Xebow.Frame, pixel_map: gen_map.()) end
+  generator = fn -> struct!(RGBMatrix.Frame, pixel_map: gen_map.()) end
   frames = Stream.repeatedly(generator) |> Enum.take(10)
 
   animation =
-    %Xebow.Animation{
+    %RGBMatrix.Animation{
     delay_ms: 100,
     frames: frames,
     tick: 0,
     loop: :infinite,
-    type: Xebow.Animation.Static
+    type: RGBMatrix.Animation.Static
   }
 
-  Xebow.RGBMatrix.play_animation(animation)
+  Xebow.LEDs.play_animation(animation)
   ```
 
   ### Play a pre-defined animation, three times
   ```
   frames = [
-    %Xebow.Frame{
+    %RGBMatrix.Frame{
       pixel_map: %{
         {0, 0} => %Chameleon.HSV{h: 100, s: 100, v: 100},
         {0, 1} => %Chameleon.HSV{h: 100, s: 100, v: 100},
@@ -54,7 +54,7 @@ defmodule Xebow.Animation.Static do
         {2, 3} => %Chameleon.HSV{h: 100, s: 100, v: 100}
       }
     },
-    %Xebow.Frame{
+    %RGBMatrix.Frame{
       pixel_map: %{
         {0, 0} => %Chameleon.HSV{h: 0, s: 0, v: 0},
         {0, 1} => %Chameleon.HSV{h: 0, s: 0, v: 0},
@@ -72,21 +72,21 @@ defmodule Xebow.Animation.Static do
     }
   ]
 
-  animation = %Xebow.Animation{
+  animation = %RGBMatrix.Animation{
     delay_ms: 200,
     frames: frames,
     tick: 0,
     loop: 3,
-    type: Xebow.Animation.Static
+    type: RGBMatrix.Animation.Static
   }
 
-  Xebow.RGBMatrix.play_animation(animation)
+  Xebow.LEDs.play_animation(animation)
   ```
   """
 
-  alias Xebow.Animation
+  alias RGBMatrix.Animation
 
-  import Xebow.Utils, only: [mod: 2]
+  import RGBMatrix.Utils, only: [mod: 2]
 
   use Animation
 

--- a/lib/rgb_matrix/engine.ex
+++ b/lib/rgb_matrix/engine.ex
@@ -1,12 +1,12 @@
-defmodule Xebow.Engine do
+defmodule RGBMatrix.Engine do
   @moduledoc """
-  Renders [`Animation`](`Xebow.Animation`)s and outputs
-  [`Frame`](`Xebow.Frame`)s to be displayed.
+  Renders [`Animation`](`RGBMatrix.Animation`)s and outputs
+  [`Frame`](`RGBMatrix.Frame`)s to be displayed.
   """
 
   use GenServer
 
-  alias Xebow.Animation
+  alias RGBMatrix.Animation
 
   defmodule State do
     @moduledoc false
@@ -23,8 +23,8 @@ defmodule Xebow.Engine do
 
   This function accepts the following arguments as a tuple:
   - `initial_animation` - The animation that plays when the engine starts.
-  - `paintables` - A list of modules to output `Xebow.Frame` to that implement
-      the `Xebow.Paintable` behavior. If you want to register your paintables
+  - `paintables` - A list of modules to output `RGBMatrix.Frame` to that implement
+      the `RGBMatrix.Paintable` behavior. If you want to register your paintables
       dynamically, set this to an empty list `[]`.
   """
   @spec start_link({initial_animation :: Animation.t(), paintables :: list(module)}) ::
@@ -52,7 +52,7 @@ defmodule Xebow.Engine do
   end
 
   @doc """
-  Register a `Xebow.Paintable` for the engine to paint pixels to.
+  Register a `RGBMatrix.Paintable` for the engine to paint pixels to.
   This function is idempotent.
   """
   @spec register_paintable(paintable :: module) :: :ok
@@ -61,7 +61,7 @@ defmodule Xebow.Engine do
   end
 
   @doc """
-  Unregister a `Xebow.Paintable` so the engine no longer paints pixels to it.
+  Unregister a `RGBMatrix.Paintable` so the engine no longer paints pixels to it.
   This function is idempotent.
   """
   @spec unregister_paintable(paintable :: module) :: :ok

--- a/lib/rgb_matrix/frame.ex
+++ b/lib/rgb_matrix/frame.ex
@@ -1,4 +1,4 @@
-defmodule Xebow.Frame do
+defmodule RGBMatrix.Frame do
   @moduledoc """
   Provides a data structure and functions for working with animation frames.
 
@@ -6,7 +6,7 @@ defmodule Xebow.Frame do
   list of frames or each frame can be dynamically generated based on the tick of some animation.
   """
 
-  alias Xebow.Pixel
+  alias RGBMatrix.Pixel
 
   @type pixel_map :: %{required(Pixel.t()) => Pixel.color()}
 

--- a/lib/rgb_matrix/paintable.ex
+++ b/lib/rgb_matrix/paintable.ex
@@ -1,4 +1,4 @@
-defmodule Xebow.Paintable do
+defmodule RGBMatrix.Paintable do
   @moduledoc """
   A paintable module controls physical pixels.
   """
@@ -10,5 +10,5 @@ defmodule Xebow.Paintable do
   This callback makes any hardware implementation details opaque to the caller,
   while allowing the paintable to retain control of the physical pixels.
   """
-  @callback get_paint_fn :: (frame :: Xebow.Frame.t() -> any)
+  @callback get_paint_fn :: (frame :: RGBMatrix.Frame.t() -> any)
 end

--- a/lib/rgb_matrix/pixel.ex
+++ b/lib/rgb_matrix/pixel.ex
@@ -1,4 +1,4 @@
-defmodule Xebow.Pixel do
+defmodule RGBMatrix.Pixel do
   @moduledoc """
   A pixel is a unit that has X and Y coordinates and displays a single color.
   """

--- a/lib/rgb_matrix/utils.ex
+++ b/lib/rgb_matrix/utils.ex
@@ -1,4 +1,4 @@
-defmodule Xebow.Utils do
+defmodule RGBMatrix.Utils do
   @moduledoc """
   Shared utility functions that are generally useful.
   """
@@ -19,24 +19,4 @@ defmodule Xebow.Utils do
         remainder
     end
   end
-
-  # pixels on the xebow start in upper left corner and count down instead of
-  # across
-  @pixels [
-    {0, 0},
-    {0, 1},
-    {0, 2},
-    {0, 3},
-    {1, 0},
-    {1, 1},
-    {1, 2},
-    {1, 3},
-    {2, 0},
-    {2, 1},
-    {2, 2},
-    {2, 3}
-  ]
-
-  @spec pixels() :: list(RGBMatrix.Pixel.t())
-  def pixels, do: @pixels
 end

--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -5,8 +5,8 @@ defmodule Xebow.Application do
 
   use Application
 
-  @animation_type Xebow.Animation.types() |> List.first()
-  @animation Xebow.Animation.new(type: @animation_type)
+  @animation_type RGBMatrix.Animation.types() |> List.first()
+  @animation RGBMatrix.Animation.new(type: @animation_type)
 
   def start(_type, _args) do
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -38,9 +38,9 @@ defmodule Xebow.Application do
       # Starts a worker by calling: Xebow.Worker.start_link(arg)
       # {Xebow.Worker, arg},
       Xebow.HIDGadget,
-      Xebow.RGBMatrix,
-      {Xebow.Engine, {@animation, [Xebow.RGBMatrix]}},
-      Xebow.Keys
+      Xebow.LEDs,
+      {RGBMatrix.Engine, {@animation, [Xebow.LEDs]}},
+      Xebow.Keyboard
     ]
   end
 

--- a/lib/xebow/hid_gadget.ex
+++ b/lib/xebow/hid_gadget.ex
@@ -1,6 +1,8 @@
 defmodule Xebow.HIDGadget do
   @moduledoc """
-  Set up the gadget devices with usb_gadget
+  Set up the gadget devices with usb_gadget.
+
+  This sets up a composite USB device with ethernet (ecm + rndis) and HID.
   """
 
   use GenServer, restart: :temporary

--- a/lib/xebow/leds.ex
+++ b/lib/xebow/leds.ex
@@ -1,5 +1,13 @@
-defmodule Xebow.RGBMatrix do
-  @behaviour Xebow.Paintable
+defmodule Xebow.LEDs do
+  @moduledoc """
+  GenServer that interacts with the SPI device that controls the RGB LEDs on the
+  Keybow.
+
+  It also implements the RGBMatrix.Paintable behavior so that the RGBMatrix
+  effects can be painted onto the keybow's RGB LEDs.
+  """
+
+  @behaviour RGBMatrix.Paintable
 
   use GenServer
 
@@ -21,7 +29,7 @@ defmodule Xebow.RGBMatrix do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  @impl Xebow.Paintable
+  @impl RGBMatrix.Paintable
   def get_paint_fn do
     GenServer.call(__MODULE__, :get_paint_fn)
   end

--- a/test/rgb_matrix/engine_test.exs
+++ b/test/rgb_matrix/engine_test.exs
@@ -1,9 +1,9 @@
-defmodule Xebow.EngineTest do
+defmodule RGBMatrix.EngineTest do
   use ExUnit.Case
 
-  alias Xebow.{Animation, Engine, Frame}
+  alias RGBMatrix.{Animation, Engine, Frame}
 
-  # Creates a Xebow.Paintable module that emits frames to the test suite process.
+  # Creates a RGBMatrix.Paintable module that emits frames to the test suite process.
   defp paintable(%{test: test_name}) do
     process = self()
     module_name = String.to_atom("#{test_name}-paintable")


### PR DESCRIPTION
This is the first step in me trying to integrate my RGBMatrix effects work into Xebow.  First, let's move out all RGBMatrix concerns into its own top-level namespace so we don't mix with Xebow concerns.  This PR also contains a few module renames and some documentation updates.