### PR TITLE
Add mix upload command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ Remove the MicroSD card and insert it into the keybow. Plug the keybow into the
 computer and wait for it to boot. Once booted, the keypad should begin cycling
 all keys through a rainbow of colors.
 
+## Updating the firmware
+
+The firmware can be updated while the Keybow is attached to your computer as
+long as the Xebow firmware is running on it.
+
+First, generate a firmware package from the current source code:
+
+    $ mix firmware
+
+Then upload the firmware to the device over SSH:
+
+    $ mix upload
+
+Notes
+- The upload needs to be run on a computer with the same SSH public key that was
+  used when burning the SD card or else it won't be able to connect to the Keybow.
+- If the `xebow.local` hostname can't be resolved, try unplugging the Keybow
+  from the USB port, wait for the computer's USB disconnect notification, then
+  plug the Keybow back in and try again after it's booted back up.
+
 # Keyboard Layout
 
 The xebow firmware sets up the keybow as a 10-key numpad. Turn the keypad so the

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,8 @@ defmodule Xebow.MixProject do
     [
       dialyzer: "do cmd mkdir -p _build/#{Mix.target()}_#{Mix.env()}/plt, dialyzer",
       "docs.show": "do docs, cmd xdg-open doc/index.html",
-      loadconfig: [&bootstrap/1]
+      loadconfig: [&bootstrap/1],
+      upload: "cmd ./upload.sh"
     ]
   end
 


### PR DESCRIPTION
This PR adds the ability to run `mix upload` as a more idiomatic way to update the firmware. It runs the `./upload.sh` script under the hood.

I've also added some docs about updating the firmware.