### PR TITLE
Compile static assets when building the firmware bundle

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,9 @@ defmodule Xebow.MixProject do
 
   defp aliases do
     [
+      "compile.assets": "cmd npm run deploy --prefix ./assets",
       "docs.show": "do docs, cmd xdg-open doc/index.html",
+      firmware: ["compile.assets", "firmware"],
       loadconfig: [&bootstrap/1],
       upload: "upload xebow.local",
       setup: ["deps.get", "cmd npm install --prefix assets"]


### PR DESCRIPTION
For #46 

This PR adds the mix command `compile.assets` to compile the Phoenix static assets, and wraps the mix `firmware` command to compile the static assets when building the firmware bundle.