### PR TITLE
Add mix firmware.upload alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,12 @@ all keys through a rainbow of colors.
 The firmware can be updated while the Keybow is attached to your computer as
 long as the Xebow firmware is running on it.
 
-First, generate a firmware package from the current source code:
+Build the firmware and upload it via SSH by running:
 
-    $ mix firmware
+    $ mix firmware.upload
 
-Then upload the firmware to the device over SSH:
-
-    $ mix upload
+If you would like to perform these steps individually, use `mix firmware`
+and `mix upload`.
 
 Notes
 - The upload needs to be run on a computer with the same SSH public key that was

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,7 @@ defmodule Xebow.MixProject do
         dialyzer: :keybow,
         docs: :keybow,
         firmware: :keybow,
+        "firmware.upload": :keybow,
         upload: :keybow
       ],
       dialyzer: [
@@ -62,6 +63,7 @@ defmodule Xebow.MixProject do
       "compile.assets": "cmd npm run deploy --prefix ./assets",
       "docs.show": "do docs, cmd xdg-open doc/index.html",
       firmware: ["compile.assets", "firmware"],
+      "firmware.upload": ["firmware", "upload"],
       loadconfig: [&bootstrap/1],
       upload: "upload xebow.local",
       setup: ["deps.get", "cmd npm install --prefix assets"]


### PR DESCRIPTION
This PR adds the mix alias `firmware.upload` to combine the steps of building the firmware and uploading it to the Keybow. The readme has also been updated accordingly.