### PR TITLE
Finishing touches for running on the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ Notes
   from the USB port, wait for the computer's USB disconnect notification, then
   plug the Keybow back in and try again after it's booted back up.
 
+## Web Interface
+
+The following instructions are for running the Xebow web interface on your
+computer for a faster development cycle.
+
+If this is your first time running the web interface, set up the web app with:
+
+    $ mix setup
+
+Start the web interface, which will be available at `http://localhost:4000`:
+
+    $ mix phx.server
+
 # Keyboard Layout
 
 The xebow firmware sets up the keybow as a 10-key numpad. Turn the keypad so the

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,12 +17,6 @@ config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 
 config :nerves, source_date_epoch: "1581654358"
 
-# Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
-# configuring ring_logger.
-
-config :logger, backends: [RingLogger]
-
 # Phoenix config:
 # Common config between host and targets
 config :xebow, XebowWeb.Endpoint,

--- a/config/keybow/config.exs
+++ b/config/keybow/config.exs
@@ -81,6 +81,12 @@ config :mdns_lite,
     }
   ]
 
+# Use Ringlogger as the logger backend and remove :console.
+# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# configuring ring_logger.
+
+config :logger, backends: [RingLogger]
+
 # Phoenix config:
 # Configures the endpoint
 config :xebow, XebowWeb.Endpoint,

--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -18,6 +18,11 @@ defmodule Xebow.Application do
         # Children for all targets
         # Starts a worker by calling: Xebow.Worker.start_link(arg)
         # {Xebow.Worker, arg},
+        {RGBMatrix.Engine, {@leds, @animation_type}},
+        # Phoenix:
+        XebowWeb.Telemetry,
+        {Phoenix.PubSub, name: Xebow.PubSub},
+        XebowWeb.Endpoint
       ] ++ children(target())
 
     Supervisor.start_link(children, opts)
@@ -29,10 +34,6 @@ defmodule Xebow.Application do
       # Children that only run on the host
       # Starts a worker by calling: Xebow.Worker.start_link(arg)
       # {Xebow.Worker, arg},
-      {RGBMatrix.Engine, {@leds, @animation_type}},
-      XebowWeb.Telemetry,
-      {Phoenix.PubSub, name: Xebow.PubSub},
-      XebowWeb.Endpoint
     ]
   end
 
@@ -42,13 +43,8 @@ defmodule Xebow.Application do
       # Starts a worker by calling: Xebow.Worker.start_link(arg)
       # {Xebow.Worker, arg},
       Xebow.HIDGadget,
-      {RGBMatrix.Engine, {@leds, @animation_type}},
       Xebow.LEDs,
-      Xebow.Keyboard,
-      # Phoenix:
-      XebowWeb.Telemetry,
-      {Phoenix.PubSub, name: Xebow.PubSub},
-      XebowWeb.Endpoint
+      Xebow.Keyboard
     ]
   end
 

--- a/lib/xebow/hid_gadget.ex
+++ b/lib/xebow/hid_gadget.ex
@@ -5,6 +5,9 @@ defmodule Xebow.HIDGadget do
   This sets up a composite USB device with ethernet (ecm + rndis) and HID.
   """
 
+  if Mix.target() == :host,
+    do: @compile({:no_warn_undefined, USBGadget})
+
   use GenServer, restart: :temporary
 
   require Logger

--- a/lib/xebow/keyboard.ex
+++ b/lib/xebow/keyboard.ex
@@ -14,6 +14,9 @@ defmodule Xebow.Keyboard do
      `Xebow.HIDGadget`
   """
 
+  if Mix.target() == :host,
+    do: @compile({:no_warn_undefined, Circuits.GPIO})
+
   use GenServer
 
   alias Circuits.GPIO

--- a/lib/xebow/leds.ex
+++ b/lib/xebow/leds.ex
@@ -7,6 +7,9 @@ defmodule Xebow.LEDs do
   painted onto the keybow's RGB LEDs.
   """
 
+  if Mix.target() == :host,
+    do: @compile({:no_warn_undefined, Circuits.SPI})
+
   use GenServer
 
   alias Circuits.SPI

--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,7 @@ defmodule Xebow.MixProject do
       {:jason, "~> 1.0"},
       {:phoenix_html, "~> 2.11"},
       {:phoenix_live_dashboard, "~> 0.2.0"},
-      {:phoenix_live_reload, "~> 1.2", only: :dev},
+      {:phoenix_live_reload, "~> 1.2", only: :dev, targets: :host},
       {:phoenix_live_view, "~> 0.13.0"},
       {:phoenix, "~> 1.5.3"},
       {:plug_cowboy, "~> 2.0"},


### PR DESCRIPTION
Resolves #46

This PR wraps up the outstanding items from #46 and allows `iex` and the Live View web interface to run on the host. Refer to the commit messages for each of the changes.

Note: I suppressed the compiler warnings for missing modules, like Circuits, with the `@compile` `:no_warn_undefined` option. A better way would probably be to inject mock dependencies, but I thought that task may be a better thing to do at the time of writing the tests for each module. Part of this PR includes moving modules around to the right places in the application supervisor, so the modules with warnings won't start on the host anyway.