### PR TITLE
Change layout Key and LED float types to number

### DIFF
--- a/lib/layout.ex
+++ b/lib/layout.ex
@@ -5,14 +5,12 @@ defmodule Layout do
 
   alias __MODULE__.{Key, LED}
 
-  # FIXME: what's wrong with this type?
-  # @type t :: %__MODULE__{
-  #         keys: [Key.t()],
-  #         leds: [LED.t()],
-  #         leds_by_keys: %{Key.id() => LED.t()},
-  #         keys_by_leds: %{LED.id() => Key.t()}
-  #       }
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          keys: [Key.t()],
+          leds: [LED.t()],
+          leds_by_keys: %{Key.id() => LED.t()},
+          keys_by_leds: %{LED.id() => Key.t()}
+        }
   defstruct [:keys, :leds, :leds_by_keys, :keys_by_leds]
 
   @spec new(keys :: [Key.t()], leds :: [LED.t()]) :: t

--- a/lib/layout/key.ex
+++ b/lib/layout/key.ex
@@ -7,10 +7,10 @@ defmodule Layout.Key do
 
   @type t :: %__MODULE__{
           id: id,
-          x: float,
-          y: float,
-          width: float,
-          height: float,
+          x: number,
+          y: number,
+          width: number,
+          height: number,
           led: atom
         }
   defstruct [:id, :x, :y, :width, :height, :led]

--- a/lib/layout/led.ex
+++ b/lib/layout/led.ex
@@ -7,8 +7,8 @@ defmodule Layout.LED do
 
   @type t :: %__MODULE__{
           id: id,
-          x: float,
-          y: float
+          x: number,
+          y: number
         }
   defstruct [:id, :x, :y]
 


### PR DESCRIPTION
Resolves #82.

This PR fixes the dialyzer error that was happening with the `Layout.t` typespec. I've updated the typing of `float` in `Key.t` and `LED.t` to `number` to accommodate integers as well.