### PR TITLE
Rework Mix tasks for asset compilation and installation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,10 +60,10 @@ defmodule Xebow.MixProject do
 
   defp aliases do
     [
-      "compile.assets": "cmd npm run deploy --prefix ./assets",
+      "assets.compile": "cmd npm run deploy --prefix ./assets",
       "assets.install": "cmd npm install --prefix ./assets",
       "docs.show": "do docs, cmd xdg-open doc/index.html",
-      firmware: ["compile.assets", "firmware"],
+      firmware: ["assets.compile", "firmware"],
       "firmware.upload": ["firmware", "upload"],
       loadconfig: [&bootstrap/1],
       upload: "upload xebow.local",

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Xebow.MixProject do
 
   defp aliases do
     [
-      "assets.compile": "cmd npm run deploy --prefix ./assets",
+      "assets.compile": assets_compile(),
       "assets.install": "cmd npm install --prefix ./assets",
       "docs.show": "do docs, cmd xdg-open doc/index.html",
       firmware: ["assets.compile", "firmware"],
@@ -123,5 +123,15 @@ defmodule Xebow.MixProject do
       steps: [&Nerves.Release.init/1, :assemble],
       strip_beams: Mix.env() == :prod
     ]
+  end
+
+  defp assets_compile do
+    compile_command = "cmd npm run deploy --prefix ./assets"
+
+    if File.dir?("./assets/node_modules") do
+      compile_command
+    else
+      ["assets.install", compile_command]
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -61,12 +61,13 @@ defmodule Xebow.MixProject do
   defp aliases do
     [
       "compile.assets": "cmd npm run deploy --prefix ./assets",
+      "assets.install": "cmd npm install --prefix ./assets",
       "docs.show": "do docs, cmd xdg-open doc/index.html",
       firmware: ["compile.assets", "firmware"],
       "firmware.upload": ["firmware", "upload"],
       loadconfig: [&bootstrap/1],
       upload: "upload xebow.local",
-      setup: ["deps.get", "cmd npm install --prefix assets"]
+      setup: ["deps.get", "assets.install"]
     ]
   end
 


### PR DESCRIPTION
This adds an `assets.install` task which runs `npm run install --prefix ./assets`. It also renames the asset compilation Mix task from `compile.assets` to `assets.compile` and makes the task conditionally run `assets.install` if the directory `./assets/node_modules` doesn't exist.

Resolves #92