### PR TITLE
Move animation management out of Engine

### DIFF
--- a/lib/rgb_matrix/animation.ex
+++ b/lib/rgb_matrix/animation.ex
@@ -63,7 +63,7 @@ defmodule RGBMatrix.Animation do
   def new(animation_type, leds) do
     config_module = Module.concat([animation_type, "Config"])
     animation_config = config_module.new()
-    {render_in, animation_state} = animation_type.new(leds, animation_config)
+    {0, animation_state} = animation_type.new(leds, animation_config)
 
     animation = %__MODULE__{
       type: animation_type,
@@ -71,7 +71,7 @@ defmodule RGBMatrix.Animation do
       state: animation_state
     }
 
-    {render_in, animation}
+    animation
   end
 
   @doc """

--- a/lib/rgb_matrix/animation.ex
+++ b/lib/rgb_matrix/animation.ex
@@ -65,13 +65,11 @@ defmodule RGBMatrix.Animation do
     animation_config = config_module.new()
     animation_state = animation_type.new(leds, animation_config)
 
-    animation = %__MODULE__{
+    %__MODULE__{
       type: animation_type,
       config: animation_config,
       state: animation_state
     }
-
-    animation
   end
 
   @doc """
@@ -114,8 +112,6 @@ defmodule RGBMatrix.Animation do
 
     config = config_module.update(config, params)
 
-    animation = %{animation | config: config}
-    :ok = Xebow.update_animation_config(animation)
-    animation
+    %{animation | config: config}
   end
 end

--- a/lib/rgb_matrix/animation.ex
+++ b/lib/rgb_matrix/animation.ex
@@ -15,7 +15,7 @@ defmodule RGBMatrix.Animation do
         }
   defstruct [:type, :config, :state]
 
-  @callback new(leds :: [LED.t()], config :: Config.t()) :: {render_in, animation_state}
+  @callback new(leds :: [LED.t()], config :: Config.t()) :: animation_state
   @callback render(state :: animation_state, config :: Config.t()) ::
               {render_in, [RGBMatrix.any_color_model()], animation_state}
   @callback interact(state :: animation_state, config :: Config.t(), led :: LED.t()) ::
@@ -59,11 +59,11 @@ defmodule RGBMatrix.Animation do
   @doc """
   Returns an animation's initial state.
   """
-  @spec new(animation_type :: type, leds :: [LED.t()]) :: {render_in, t}
+  @spec new(animation_type :: type, leds :: [LED.t()]) :: t
   def new(animation_type, leds) do
     config_module = Module.concat([animation_type, "Config"])
     animation_config = config_module.new()
-    {0, animation_state} = animation_type.new(leds, animation_config)
+    animation_state = animation_type.new(leds, animation_config)
 
     animation = %__MODULE__{
       type: animation_type,

--- a/lib/rgb_matrix/animation.ex
+++ b/lib/rgb_matrix/animation.ex
@@ -114,6 +114,8 @@ defmodule RGBMatrix.Animation do
 
     config = config_module.update(config, params)
 
-    %{animation | config: config}
+    animation = %{animation | config: config}
+    :ok = Xebow.update_animation_config(animation)
+    animation
   end
 end

--- a/lib/rgb_matrix/animation/breathing.ex
+++ b/lib/rgb_matrix/animation/breathing.ex
@@ -24,7 +24,7 @@ defmodule RGBMatrix.Animation.Breathing do
   def new(leds, _config) do
     color = HSV.new(40, 100, 100)
     led_ids = Enum.map(leds, & &1.id)
-    {0, %State{color: color, tick: 0, speed: 100, led_ids: led_ids}}
+    %State{color: color, tick: 0, speed: 100, led_ids: led_ids}
   end
 
   @impl true

--- a/lib/rgb_matrix/animation/cycle_all.ex
+++ b/lib/rgb_matrix/animation/cycle_all.ex
@@ -25,7 +25,7 @@ defmodule RGBMatrix.Animation.CycleAll do
   @impl true
   def new(leds, _config) do
     led_ids = Enum.map(leds, & &1.id)
-    {0, %State{tick: 0, speed: 100, led_ids: led_ids}}
+    %State{tick: 0, speed: 100, led_ids: led_ids}
   end
 
   @impl true

--- a/lib/rgb_matrix/animation/hue_wave.ex
+++ b/lib/rgb_matrix/animation/hue_wave.ex
@@ -51,7 +51,7 @@ defmodule RGBMatrix.Animation.HueWave do
   @impl true
   def new(leds, config) do
     steps = 360 / config.width
-    {0, %State{tick: 0, leds: leds, steps: steps}}
+    %State{tick: 0, leds: leds, steps: steps}
   end
 
   @impl true

--- a/lib/rgb_matrix/animation/pinwheel.ex
+++ b/lib/rgb_matrix/animation/pinwheel.ex
@@ -25,7 +25,7 @@ defmodule RGBMatrix.Animation.Pinwheel do
 
   @impl true
   def new(leds, _config) do
-    {0, %State{tick: 0, speed: 100, leds: leds, center: determine_center(leds)}}
+    %State{tick: 0, speed: 100, leds: leds, center: determine_center(leds)}
   end
 
   defp determine_center(leds) do

--- a/lib/rgb_matrix/animation/random_keypresses.ex
+++ b/lib/rgb_matrix/animation/random_keypresses.ex
@@ -22,12 +22,11 @@ defmodule RGBMatrix.Animation.RandomKeypresses do
   def new(leds, _config) do
     led_ids = Enum.map(leds, & &1.id)
 
-    {0,
      %State{
        led_ids: led_ids,
        # NOTE: as to not conflict with possible led ID of `:all`
        dirty: {:all}
-     }}
+     }
   end
 
   @impl true

--- a/lib/rgb_matrix/animation/random_keypresses.ex
+++ b/lib/rgb_matrix/animation/random_keypresses.ex
@@ -22,11 +22,11 @@ defmodule RGBMatrix.Animation.RandomKeypresses do
   def new(leds, _config) do
     led_ids = Enum.map(leds, & &1.id)
 
-     %State{
-       led_ids: led_ids,
-       # NOTE: as to not conflict with possible led ID of `:all`
-       dirty: {:all}
-     }
+    %State{
+      led_ids: led_ids,
+      # NOTE: as to not conflict with possible led ID of `:all`
+      dirty: {:all}
+    }
   end
 
   @impl true

--- a/lib/rgb_matrix/animation/random_solid.ex
+++ b/lib/rgb_matrix/animation/random_solid.ex
@@ -20,7 +20,7 @@ defmodule RGBMatrix.Animation.RandomSolid do
 
   @impl true
   def new(leds, _config) do
-    {0, %State{led_ids: Enum.map(leds, & &1.id)}}
+    %State{led_ids: Enum.map(leds, & &1.id)}
   end
 
   @impl true

--- a/lib/rgb_matrix/animation/solid_color.ex
+++ b/lib/rgb_matrix/animation/solid_color.ex
@@ -21,7 +21,7 @@ defmodule RGBMatrix.Animation.SolidColor do
   @impl true
   def new(leds, _config) do
     color = HSV.new(120, 100, 100)
-    {0, %State{color: color, led_ids: Enum.map(leds, & &1.id)}}
+    %State{color: color, led_ids: Enum.map(leds, & &1.id)}
   end
 
   @impl true

--- a/lib/rgb_matrix/animation/solid_reactive.ex
+++ b/lib/rgb_matrix/animation/solid_reactive.ex
@@ -49,7 +49,7 @@ defmodule RGBMatrix.Animation.SolidReactive do
   @impl true
   def new(leds, _config) do
     color = HSV.new(190, 100, 100)
-    {0, %State{first_render: true, paused: false, tick: 0, color: color, leds: leds, hits: %{}}}
+    %State{first_render: true, paused: false, tick: 0, color: color, leds: leds, hits: %{}}
   end
 
   @impl true

--- a/lib/rgb_matrix/engine.ex
+++ b/lib/rgb_matrix/engine.ex
@@ -129,14 +129,6 @@ defmodule RGBMatrix.Engine do
     %State{state | paintables: paintables}
   end
 
-  #  defp set_animation(state, animation) do
-  #    # {render_in, animation} = Animation.new(animation_type, state.leds)
-  #
-  #    %State{state | animation: animation}
-  #    |> schedule_next_render(0)
-  #    |> inform_configurables()
-  #  end
-
   defp schedule_next_render(state, :ignore) do
     state
   end

--- a/lib/rgb_matrix/engine.ex
+++ b/lib/rgb_matrix/engine.ex
@@ -72,14 +72,6 @@ defmodule RGBMatrix.Engine do
   end
 
   @doc """
-  Retrieves the current animation's configuration and configuration schema.
-  """
-  @spec get_animation_config() :: {config :: any, config_schema :: any}
-  def get_animation_config do
-    GenServer.call(__MODULE__, :get_animation_config)
-  end
-
-  @doc """
   Updates the current animation's configuration.
   """
   @spec update_animation_config(params :: map) :: :ok | :error

--- a/lib/xebow.ex
+++ b/lib/xebow.ex
@@ -1,5 +1,8 @@
 defmodule Xebow do
-  @moduledoc false
+  @moduledoc """
+  Xebow is an Elixir-based firmware for keyboards. Currently, it is working on the Raspberry Pi0
+  Keybow kit.
+  """
 
   alias Layout.{Key, LED}
 
@@ -47,16 +50,37 @@ defmodule Xebow do
     GenServer.start_link(__MODULE__, RGBMatrix.Animation.types(), name: __MODULE__)
   end
 
+  @doc """
+  Gets the current animation configuration. This retrievs current values, which
+  allows for changes to be made with `update_animation_config/2`
+  """
+  @spec get_animation_config() :: RGBMatrix.Animation.Config.t()
+  def get_animation_config do
+    GenServer.call(__MODULE__, :get_animation_config)
+  end
+
+  @doc """
+  Switches to the next active animation
+  """
+  @spec next_animation() :: :ok
   def next_animation do
     GenServer.cast(__MODULE__, :next_animation)
   end
 
+  @doc """
+  Switches to the previous active animation
+  """
+  @spec previous_animation() :: :ok
   def previous_animation do
     GenServer.cast(__MODULE__, :previous_animation)
   end
 
-  def get_animation_config do
-    GenServer.call(__MODULE__, :get_animation_config)
+  @doc """
+  Updates the animation configuration for the current animation
+  """
+  @spec update_animation_config(RGBMatrix.Animation.type()) :: :ok | :error
+  def update_animation_config(animation_with_config) do
+    GenServer.call(__MODULE__, {:update_animation_config, animation_with_config})
   end
 
   # Server Implementations:
@@ -78,6 +102,12 @@ defmodule Xebow do
   def handle_call(:get_animation_config, _caller, state) do
     {[current | _rest], _previous} = state
     {:reply, RGBMatrix.Animation.get_config(current), state}
+  end
+
+  @impl GenServer
+  def handle_call({:update_animation_config, animation_with_config}, _caller, state) do
+    {[_current | rest], previous} = state
+    {:reply, :ok, {[animation_with_config | rest], previous}}
   end
 
   @impl GenServer

--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -6,7 +6,6 @@ defmodule Xebow.Application do
   use Application
 
   @leds Xebow.layout() |> Layout.leds()
-  @animation_type RGBMatrix.Animation.types() |> List.first()
 
   def start(_type, _args) do
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -18,7 +17,9 @@ defmodule Xebow.Application do
         # Children for all targets
         # Starts a worker by calling: Xebow.Worker.start_link(arg)
         # {Xebow.Worker, arg},
-        {RGBMatrix.Engine, {@leds, @animation_type}},
+        # Engine must be started before Xebow
+        {RGBMatrix.Engine, @leds},
+        Xebow,
         # Phoenix:
         XebowWeb.Telemetry,
         {Phoenix.PubSub, name: Xebow.PubSub},

--- a/lib/xebow/keyboard.ex
+++ b/lib/xebow/keyboard.ex
@@ -20,7 +20,7 @@ defmodule Xebow.Keyboard do
   use GenServer
 
   alias Circuits.GPIO
-  alias RGBMatrix.{Animation, Engine}
+  alias RGBMatrix.Engine
 
   # maps the physical GPIO pins to key IDs
   @gpio_pins %{
@@ -101,7 +101,7 @@ defmodule Xebow.Keyboard do
   """
   @spec next_animation() :: :ok
   def next_animation do
-    GenServer.cast(__MODULE__, :next_animation)
+    Xebow.next_animation()
   end
 
   @doc """
@@ -109,7 +109,7 @@ defmodule Xebow.Keyboard do
   """
   @spec previous_animation() :: :ok
   def previous_animation do
-    GenServer.cast(__MODULE__, :previous_animation)
+    Xebow.previous_animation()
   end
 
   # Server
@@ -141,49 +141,9 @@ defmodule Xebow.Keyboard do
       pins: pins,
       keyboard_state: keyboard_state,
       hid: hid,
-      animation_types: Animation.types(),
-      current_animation_index: 0
     }
 
     {:ok, state}
-  end
-
-  @impl GenServer
-  def handle_cast(:next_animation, state) do
-    next_index = state.current_animation_index + 1
-
-    next_index =
-      case next_index < Enum.count(state.animation_types) do
-        true -> next_index
-        _ -> 0
-      end
-
-    animation_type = Enum.at(state.animation_types, next_index)
-
-    RGBMatrix.Engine.set_animation(animation_type)
-
-    state = %{state | current_animation_index: next_index}
-
-    {:noreply, state}
-  end
-
-  @impl GenServer
-  def handle_cast(:previous_animation, state) do
-    previous_index = state.current_animation_index - 1
-
-    previous_index =
-      case previous_index < 0 do
-        true -> Enum.count(state.animation_types) - 1
-        _ -> previous_index
-      end
-
-    animation_type = Enum.at(state.animation_types, previous_index)
-
-    RGBMatrix.Engine.set_animation(animation_type)
-
-    state = %{state | current_animation_index: previous_index}
-
-    {:noreply, state}
   end
 
   @impl GenServer

--- a/lib/xebow/keyboard.ex
+++ b/lib/xebow/keyboard.ex
@@ -140,7 +140,7 @@ defmodule Xebow.Keyboard do
     state = %{
       pins: pins,
       keyboard_state: keyboard_state,
-      hid: hid,
+      hid: hid
     }
 
     {:ok, state}

--- a/lib/xebow/leds.ex
+++ b/lib/xebow/leds.ex
@@ -66,7 +66,7 @@ defmodule Xebow.LEDs do
   defp register_with_engine!(spidev) do
     pid = self()
 
-    {:ok, paint_fn} =
+    {:ok, paint_fn, _frame} =
       Engine.register_paintable(fn frame ->
         if Process.alive?(pid) do
           paint(spidev, frame)

--- a/lib/xebow_web/live/matrix_live.ex
+++ b/lib/xebow_web/live/matrix_live.ex
@@ -3,7 +3,7 @@ defmodule XebowWeb.MatrixLive do
 
   use XebowWeb, :live_view
 
-  alias RGBMatrix.{Animation, Engine}
+  alias RGBMatrix.Engine
 
   @layout Xebow.layout()
   @black Chameleon.HSV.new(0, 0, 0)
@@ -15,14 +15,12 @@ defmodule XebowWeb.MatrixLive do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {config, config_schema} = Engine.get_animation_config()
+    {config, config_schema} = Xebow.get_animation_config()
 
     initial_assigns = [
       leds: make_view_leds(@black_frame),
       config: config,
       config_schema: config_schema,
-      animation_types: Animation.types(),
-      current_animation_index: 0
     ]
 
     initial_assigns =
@@ -76,36 +74,40 @@ defmodule XebowWeb.MatrixLive do
 
   @impl Phoenix.LiveView
   def handle_event("next_animation", %{}, socket) do
-    next_index = socket.assigns.current_animation_index + 1
+    Xebow.next_animation()
+    {:noreply, socket}
+    # next_index = socket.assigns.current_animation_index + 1
 
-    next_index =
-      case next_index < Enum.count(socket.assigns.animation_types) do
-        true -> next_index
-        _ -> 0
-      end
+    # next_index =
+      # case next_index < Enum.count(socket.assigns.animation_types) do
+        # true -> next_index
+        # _ -> 0
+      # end
 
-    animation_type = Enum.at(socket.assigns.animation_types, next_index)
+    # animation_type = Enum.at(socket.assigns.animation_types, next_index)
 
-    RGBMatrix.Engine.set_animation(animation_type)
+    # RGBMatrix.Engine.set_animation(animation_type)
 
-    {:noreply, assign(socket, current_animation_index: next_index)}
+    # {:noreply, assign(socket, current_animation_index: next_index)}
   end
 
   @impl Phoenix.LiveView
   def handle_event("previous_animation", %{}, socket) do
-    previous_index = socket.assigns.current_animation_index - 1
+    Xebow.previous_animation()
+    {:noreply, socket}
+    # previous_index = socket.assigns.current_animation_index - 1
 
-    previous_index =
-      case previous_index < 0 do
-        true -> Enum.count(socket.assigns.animation_types) - 1
-        _ -> previous_index
-      end
+    # previous_index =
+      # case previous_index < 0 do
+        # true -> Enum.count(socket.assigns.animation_types) - 1
+        # _ -> previous_index
+      # end
 
-    animation_type = Enum.at(socket.assigns.animation_types, previous_index)
+    # animation_type = Enum.at(socket.assigns.animation_types, previous_index)
 
-    RGBMatrix.Engine.set_animation(animation_type)
+    # RGBMatrix.Engine.set_animation(animation_type)
 
-    {:noreply, assign(socket, current_animation_index: previous_index)}
+    # {:noreply, assign(socket, current_animation_index: previous_index)}
   end
 
   @impl Phoenix.LiveView

--- a/lib/xebow_web/live/matrix_live.ex
+++ b/lib/xebow_web/live/matrix_live.ex
@@ -63,7 +63,7 @@ defmodule XebowWeb.MatrixLive do
   def handle_event("update_config", %{"_target" => [field_str]} = params, socket) do
     value = Map.fetch!(params, field_str)
 
-    Engine.update_animation_config(%{field_str => value})
+    Xebow.update_animation_config(%{field_str => value})
 
     {:noreply, socket}
   end

--- a/lib/xebow_web/live/matrix_live.ex
+++ b/lib/xebow_web/live/matrix_live.ex
@@ -6,31 +6,23 @@ defmodule XebowWeb.MatrixLive do
   alias RGBMatrix.Engine
 
   @layout Xebow.layout()
-  @black Chameleon.HSV.new(0, 0, 0)
-  @black_frame @layout
-               |> Layout.leds()
-               |> Map.new(fn led ->
-                 {led.id, @black}
-               end)
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     {config, config_schema} = Xebow.get_animation_config()
+    {paint_fn, config_fn, frame} = register_with_engine!()
 
     initial_assigns = [
-      leds: make_view_leds(@black_frame),
+      leds: make_view_leds(frame),
       config: config,
       config_schema: config_schema
     ]
 
     initial_assigns =
       if connected?(socket) do
-        {paint_fn, config_fn, frame} = register_with_engine!()
-
         Keyword.merge(initial_assigns,
           paint_fn: paint_fn,
-          config_fn: config_fn,
-          leds: make_view_leds(frame)
+          config_fn: config_fn
         )
       else
         initial_assigns


### PR DESCRIPTION
Here, animation loading, state, and management are pulled out of `RGBMatrix.Engine` and into the `Xebow` application. This separates a few concerns to where the `Engine` only has to deal with rendering, `RGBMatrix.Animation` handles functions related to animations themselves, and `Xebow` handles creating the list of animations, initializing animations, switching animations, and persisting config modifications in memory.

This should make it easier to introduce other application controlling logic such as animation activation/deactivation, configuration persistence between reboots, and eventually runtime discovery/installation of animations (which are currently hard-coded into the animation module).

This PR also fixes the black frame on live view creation, and removes the 0-ms `render_in` that was returned by all animations on calling `new/2`. Animations which need to delay the render of their first frame could set the first frame to black, have an internal state that determines how long to wait, and check that state in its `render/2` callback functions.

addresses part of #49, but leaves open a bunch of questions aboutruntime discovery of animations, enabling/disabling, etc.
closes #80 
closes #83 