### PR TITLE
Update the note about the project being in early development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Xebow is a [nerves-based](https://nerves-project.org/) firmware for the
 [Keybow](https://shop.pimoroni.com/products/keybow?variant=21246333190227)
 keypad.
 
-This project is still in **early development** and only functions as a basic
-keypad with the ability to cycle through a few LED animations and control sound
-volume.
+This project is in **early development**. Features and the API may be subject
+to change.
 
 - Join the `#nerves-keyboard` channel on the [elixir-lang Slack](https://elixir-slackin.herokuapp.com/)
 to chat with us and keep up on the latest developments.


### PR DESCRIPTION
I thought it may be beneficial to remove the note about only having basic functionality, because the current functionality is pretty cool to play around with and we're continuously adding to it. So instead I replaced this with a note that the features and API may be subject to change, which may be the thing that's more likely to frustrate people who do not like to be early adopters.