### PR TITLE
Only validate firmware on target

### DIFF
--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -7,9 +7,16 @@ defmodule Xebow.Application do
 
   @leds Xebow.layout() |> Layout.leds()
 
-  def start(_type, _args) do
-    if Mix.target() != :host,
+  if Mix.target() == :host do
+    defp maybe_validate_firmware,
+      do: nil
+  else
+    defp maybe_validate_firmware,
       do: Nerves.Runtime.validate_firmware()
+  end
+
+  def start(_type, _args) do
+    maybe_validate_firmware()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options


### PR DESCRIPTION
Related to #97 

Without this modification the following warning occurs because `Nerves.Runtime` is not available on the host. This new code prevents `Nerves.Runtime` from being compiled in on `host`.

```
warning: Nerves.Runtime.validate_firmware/0 is undefined (module Nerves.Runtime is not available or is
yet to be defined)
```