### PR TITLE
Create animations page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ npm-debug.log
 # The directory NPM downloads your dependencies sources to.
 /assets/node_modules/
 
+# Ignore user settings.
+/priv/settings
+/priv/settings_test
+
 # Since we are building assets from assets/,
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -9,6 +9,7 @@
 @import "../node_modules/nprogress/nprogress.css";
 
 @import "./button.scss";
+@import "./dropdown.scss";
 @import "./live_view.scss";
 @import "./keypad.scss";
 @import "./select.scss";

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -14,6 +14,7 @@
 @import "./keypad.scss";
 @import "./select.scss";
 @import "./slider.scss";
+@import "./toggle.scss";
 
 body {
   @apply text-white font-light bg-gray-900;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -21,3 +21,11 @@ body {
   font-family: lato, sans-serif;
   font-size: 1.375rem;
 }
+
+h2 {
+  @apply font-normal mb-8;
+}
+
+label {
+  @apply text-lg;
+}

--- a/assets/css/dropdown.scss
+++ b/assets/css/dropdown.scss
@@ -15,7 +15,7 @@
     @apply border border-gray-700 border-solid rounded;
 
     .item {
-      @apply block text-lg font-normal whitespace-no-wrap px-4 py-1;
+      @apply block text-lg font-normal whitespace-no-wrap px-3 py-1;
 
       .svg-inline--fa {
         @apply text-base mr-2 ml-0 w-5;

--- a/assets/css/dropdown.scss
+++ b/assets/css/dropdown.scss
@@ -1,0 +1,37 @@
+.dropdown {
+  @apply relative;
+
+  .button {
+    @apply cursor-pointer;
+
+    .svg-inline--fa {
+      @apply text-2xl ml-8;
+    }
+  }
+
+  .menu {
+    @apply absolute origin-top-right right-0 flex flex-col;
+    @apply bg-gray-800;
+    @apply border border-gray-700 border-solid rounded;
+
+    .item {
+      @apply block text-lg font-normal whitespace-no-wrap px-4 py-1;
+
+      .svg-inline--fa {
+        @apply text-base mr-2 ml-0 w-5;
+      }
+
+      &:hover {
+        @apply bg-blue-600;
+      }
+
+      &:first-child {
+        @apply pt-2;
+      }
+
+      &:last-child {
+        @apply pb-2;
+      }
+    }
+  }
+}

--- a/assets/css/toggle.scss
+++ b/assets/css/toggle.scss
@@ -1,0 +1,54 @@
+.toggle {
+  @apply relative;
+
+  input[type=checkbox] {
+    @apply absolute opacity-0 cursor-pointer;
+    height: 26px;
+    width: 50px;
+    top: 6px;
+    left: 0;
+    z-index: 1;
+
+    &:checked + label {
+      /* Activated track */
+      &:before {
+        @apply bg-blue-600;
+      }
+
+      /* Activated handle */
+      &:after {
+        left: 26px;
+      }
+    }
+  }
+
+  label {
+    @apply relative;
+    padding-left: 60px;
+
+    &:before, &:after {
+      @apply absolute rounded-full;
+      transition: background-color 0.3s, left 0.3s;
+    }
+
+    /* Track */
+    &:before {
+      @apply bg-blue-800 box-border;
+      content: "";
+      height: 26px;
+      width: 50px;
+      top: -6px;
+      left: 0;
+    }
+
+    /* Handle */
+    &:after {
+      @apply bg-blue-100 rounded-full;
+      content: "";
+      height: 22px;
+      width: 22px;
+      top: -4px;
+      left: 2px;
+    }
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -19,6 +19,8 @@ import {Socket} from "phoenix"
 import NProgress from "nprogress"
 import {LiveSocket} from "phoenix_live_view"
 
+import "./dropdown"
+
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 
 const Hooks = {

--- a/assets/js/dropdown.js
+++ b/assets/js/dropdown.js
@@ -1,0 +1,32 @@
+const isInvisible = (element) => {
+  return element.classList.contains("invisible")
+}
+
+const makeInvisible = (element) => {
+  element.classList.add("invisible")
+}
+
+const makeVisible = (element) => {
+  element.classList.remove("invisible")
+}
+
+const dropdownElements = document.getElementsByClassName("dropdown")
+
+Array.from(dropdownElements).forEach(dropdownElement => {
+  const buttonElement = dropdownElement.querySelector(".button")
+  const menuElement = dropdownElement.querySelector(".menu")
+
+  makeInvisible(menuElement)
+
+  buttonElement.addEventListener("click", e => {
+    if (isInvisible(menuElement))
+      makeVisible(menuElement)
+    else
+      makeInvisible(menuElement)
+  })
+
+  window.addEventListener("click", e => {
+    if (!isInvisible(menuElement) && !buttonElement.contains(e.target))
+      makeInvisible(menuElement)
+  })
+})

--- a/config/host/dev.exs
+++ b/config/host/dev.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :xebow, settings_path: "priv/settings"
+
 # Phoenix config:
 # Configures the endpoint
 config :xebow, XebowWeb.Endpoint,

--- a/config/host/test.exs
+++ b/config/host/test.exs
@@ -7,4 +7,4 @@ config :xebow, XebowWeb.Endpoint,
   server: false,
   code_reloader: false
 
-config :logger, level: :error
+config :logger, level: :warn

--- a/config/host/test.exs
+++ b/config/host/test.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :xebow, settings_path: "priv/settings_test"
+
 config :xebow, XebowWeb.Endpoint,
   http: [port: 4002],
   server: false,

--- a/config/host/test.exs
+++ b/config/host/test.exs
@@ -7,4 +7,4 @@ config :xebow, XebowWeb.Endpoint,
   server: false,
   code_reloader: false
 
-config :logger, level: :warn
+config :logger, level: :error

--- a/config/keybow/config.exs
+++ b/config/keybow/config.exs
@@ -96,4 +96,6 @@ config :xebow, XebowWeb.Endpoint,
   url: [host: "xebow.local", port: 80],
   code_reloader: false
 
+config :xebow, settings_path: "/root/settings"
+
 import_config "#{Mix.env()}.exs"

--- a/lib/rgb_matrix/animation.ex
+++ b/lib/rgb_matrix/animation.ex
@@ -49,6 +49,19 @@ defmodule RGBMatrix.Animation do
   end
 
   @doc """
+  Returns a human-readable name for an animation type.
+  """
+  @spec type_name(animation_type :: type) :: String.t()
+  def type_name(animation_type) do
+    animation_type
+    |> to_string()
+    |> String.split(".")
+    |> List.last()
+    |> String.replace(~r/([A-Z])/, " \\1")
+    |> String.trim_leading()
+  end
+
+  @doc """
   Returns an animation's initial state.
   """
   @spec new(animation_type :: type, leds :: [LED.t()]) :: t

--- a/lib/xebow.ex
+++ b/lib/xebow.ex
@@ -87,7 +87,9 @@ defmodule Xebow do
   Gets the animation configuration. This retrievs current values, which allows for
   changes to be made with `update_animation_config/1`
   """
-  @spec get_animation_config() :: {Animation.Config.t(), keyword(Animation.Config.t())}
+  @spec get_animation_config() ::
+          {Animation.Config.t(), keyword(Animation.Config.t())}
+          | nil
   def get_animation_config do
     GenServer.call(__MODULE__, :get_animation_config)
   end
@@ -156,7 +158,12 @@ defmodule Xebow do
 
   @impl GenServer
   def handle_call(:get_animation_config, _from, state) do
-    config = Animation.get_config(current_animation(state))
+    config =
+      case current_animation(state) do
+        nil -> nil
+        animation -> Animation.get_config(animation)
+      end
+
     {:reply, config, state}
   end
 

--- a/lib/xebow.ex
+++ b/lib/xebow.ex
@@ -132,7 +132,13 @@ defmodule Xebow do
           Animation.types()
       end
 
-    state = update_state_with_animation_types(%State{}, active_animation_types)
+    state =
+      %State{
+        current_index: 0,
+        active_animations: %{},
+        count_of_active_animations: 0
+      }
+      |> update_state_with_animation_types(active_animation_types)
 
     case current_animation(state) do
       nil -> nil
@@ -232,7 +238,7 @@ defmodule Xebow do
 
     active_animations =
       animation_types
-      |> Stream.map(&initialize_animation/1)
+      |> Stream.map(&new_or_existing_animation(&1, state.active_animations))
       |> Stream.with_index()
       |> Stream.map(fn {animation, index} -> {index, animation} end)
       |> Enum.into(%{})
@@ -243,5 +249,16 @@ defmodule Xebow do
         active_animations: active_animations,
         count_of_active_animations: count_of_active_animations
     }
+  end
+
+  defp new_or_existing_animation(animation_type, active_animations) do
+    existing_animation =
+      active_animations
+      |> Map.values()
+      |> Enum.find(fn animation ->
+        animation.type == animation_type
+      end)
+
+    existing_animation || initialize_animation(animation_type)
   end
 end

--- a/lib/xebow.ex
+++ b/lib/xebow.ex
@@ -123,17 +123,13 @@ defmodule Xebow do
   @impl GenServer
   def init(_) do
     active_animation_types =
-      if Settings.active_animations_file_exists?() do
-        case Settings.load_active_animations() do
-          {:ok, active_animation_types} ->
-            active_animation_types
+      case Settings.load_active_animations() do
+        {:ok, active_animation_types} ->
+          active_animation_types
 
-          {:error, reason} ->
-            Logger.warn("Failed to load active animations: #{inspect(reason)}")
-            Animation.types()
-        end
-      else
-        Animation.types()
+        {:error, reason} ->
+          Logger.warn("Failed to load active animations: #{inspect(reason)}")
+          Animation.types()
       end
 
     state = update_state_with_animation_types(%State{}, active_animation_types)

--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -17,6 +17,7 @@ defmodule Xebow.Application do
 
   def start(_type, _args) do
     maybe_validate_firmware()
+    Xebow.Settings.create_dir!()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -5,6 +5,8 @@ defmodule Xebow.Application do
 
   use Application
 
+  alias Xebow.Settings
+
   @leds Xebow.layout() |> Layout.leds()
 
   if Mix.target() == :host do
@@ -17,7 +19,8 @@ defmodule Xebow.Application do
 
   def start(_type, _args) do
     maybe_validate_firmware()
-    Xebow.Settings.create_dir!()
+    Settings.create_dir!()
+    maybe_create_animation_settings()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -62,5 +65,12 @@ defmodule Xebow.Application do
 
   def target() do
     Application.get_env(:xebow, :target)
+  end
+
+  defp maybe_create_animation_settings do
+    unless Settings.active_animations_file_exists?() && Mix.env() != :test do
+      RGBMatrix.Animation.types()
+      |> Settings.save_active_animations!()
+    end
   end
 end

--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -74,7 +74,7 @@ defmodule Xebow.Application do
   end
 
   defp maybe_create_animation_settings do
-    unless Settings.active_animations_file_exists?() && Mix.env() != :test do
+    unless Settings.active_animations_file_exists?() do
       RGBMatrix.Animation.types()
       |> Settings.save_active_animations!()
     end

--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -18,7 +18,6 @@ defmodule Xebow.Application do
   end
 
   def start(_type, _args) do
-    maybe_validate_firmware()
     Settings.create_dir!()
     maybe_create_animation_settings()
 
@@ -40,7 +39,14 @@ defmodule Xebow.Application do
         XebowWeb.Endpoint
       ] ++ children(target())
 
-    Supervisor.start_link(children, opts)
+    case Supervisor.start_link(children, opts) do
+      {:ok, pid} ->
+        maybe_validate_firmware()
+        {:ok, pid}
+
+      error ->
+        error
+    end
   end
 
   # List all child processes to be supervised

--- a/lib/xebow/settings.ex
+++ b/lib/xebow/settings.ex
@@ -3,7 +3,13 @@ defmodule Xebow.Settings do
   Application settings that are persisted to disk.
   """
 
+  alias RGBMatrix.Animation
+
   @settings_path Application.compile_env!(:xebow, :settings_path)
+
+  @animations_path Path.join(@settings_path, "animations.json")
+
+  @animations_version 1
 
   @doc """
   Create the directory for the settings files. This function is idempotent.
@@ -11,5 +17,58 @@ defmodule Xebow.Settings do
   @spec create_dir!() :: :ok
   def create_dir! do
     File.mkdir_p!(@settings_path)
+  end
+
+  @doc """
+  Save the active animations to disk.
+  """
+  @spec save_active_animations!(animation_types :: [Animation.type()]) :: :ok
+  def save_active_animations!(animation_types) do
+    create_dir!()
+
+    payload =
+      Jason.encode_to_iodata!(%{
+        schema_version: @animations_version,
+        active_animation_types: animation_types
+      })
+
+    File.write!(@animations_path, payload)
+  end
+
+  @doc """
+  Load the active animations from disk.
+  """
+  @spec load_active_animations() ::
+          {:ok, [Animation.type()]}
+          | {:error, File.posix()}
+          | {:error, :schema_mismatch}
+  def load_active_animations do
+    with {:ok, payload} <- File.read(@animations_path),
+         animation_settings <- Jason.decode!(payload),
+         :ok <- validate_schema(animation_settings, @animations_version) do
+      animation_types =
+        animation_settings["active_animation_types"]
+        |> Enum.map(&String.to_existing_atom/1)
+
+      {:ok, animation_types}
+    else
+      error -> error
+    end
+  end
+
+  @doc """
+  Returns true if the active animations settings file exists.
+  """
+  @spec active_animations_file_exists?() :: boolean
+  def active_animations_file_exists? do
+    File.exists?(@animations_path)
+  end
+
+  defp validate_schema(settings, expected_version) do
+    if settings["schema_version"] == expected_version do
+      :ok
+    else
+      {:error, :schema_mismatch}
+    end
   end
 end

--- a/lib/xebow/settings.ex
+++ b/lib/xebow/settings.ex
@@ -1,0 +1,15 @@
+defmodule Xebow.Settings do
+  @moduledoc """
+  Application settings that are persisted to disk.
+  """
+
+  @settings_path Application.compile_env!(:xebow, :settings_path)
+
+  @doc """
+  Create the directory for the settings files. This function is idempotent.
+  """
+  @spec create_dir!() :: :ok
+  def create_dir! do
+    File.mkdir_p!(@settings_path)
+  end
+end

--- a/lib/xebow_web/live/animations_live.ex
+++ b/lib/xebow_web/live/animations_live.ex
@@ -2,17 +2,56 @@ defmodule XebowWeb.AnimationsLive do
   @moduledoc false
 
   alias RGBMatrix.Animation
+  alias Xebow.Settings
 
   use XebowWeb, :live_view
 
+  require Logger
+
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, animations: animations())}
+    active_animation_types =
+      case Settings.load_active_animations() do
+        {:ok, active_animation_types} ->
+          active_animation_types
+
+        {:error, reason} ->
+          Logger.warn("Failed to load active animations: #{inspect(reason)}")
+          Animation.types()
+      end
+
+    animations =
+      animations()
+      |> Enum.map(fn animation ->
+        if animation.module in active_animation_types do
+          %{animation | is_active: true}
+        else
+          animation
+        end
+      end)
+
+    {:ok, assign(socket, animations: animations)}
   end
 
   @impl Phoenix.LiveView
-  def handle_event("toggle_animation", _params, socket) do
-    {:noreply, socket}
+  def handle_event("toggle_animation", params, socket) do
+    animations =
+      socket.assigns.animations
+      |> Enum.map(fn animation ->
+        if animation.id == params["id"] do
+          is_active = params["value"] == "true"
+          %{animation | is_active: is_active}
+        else
+          animation
+        end
+      end)
+
+    animations
+    |> Enum.filter(& &1.is_active)
+    |> Enum.map(& &1.module)
+    |> Settings.save_active_animations!()
+
+    {:noreply, assign(socket, animations: animations)}
   end
 
   defp animations do
@@ -29,7 +68,7 @@ defmodule XebowWeb.AnimationsLive do
         module: animation_module,
         id: id,
         name: name,
-        active: false
+        is_active: false
       }
     end)
     |> Enum.sort(&(&1.name < &2.name))

--- a/lib/xebow_web/live/animations_live.ex
+++ b/lib/xebow_web/live/animations_live.ex
@@ -2,23 +2,13 @@ defmodule XebowWeb.AnimationsLive do
   @moduledoc false
 
   alias RGBMatrix.Animation
-  alias Xebow.Settings
+  alias Xebow
 
   use XebowWeb, :live_view
 
-  require Logger
-
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    active_animation_types =
-      case Settings.load_active_animations() do
-        {:ok, active_animation_types} ->
-          active_animation_types
-
-        {:error, reason} ->
-          Logger.warn("Failed to load active animations: #{inspect(reason)}")
-          Animation.types()
-      end
+    active_animation_types = Xebow.get_active_animation_types()
 
     animations =
       animations()
@@ -49,7 +39,7 @@ defmodule XebowWeb.AnimationsLive do
     animations
     |> Enum.filter(& &1.is_active)
     |> Enum.map(& &1.module)
-    |> Settings.save_active_animations!()
+    |> Xebow.set_active_animation_types()
 
     {:noreply, assign(socket, animations: animations)}
   end

--- a/lib/xebow_web/live/animations_live.ex
+++ b/lib/xebow_web/live/animations_live.ex
@@ -46,6 +46,7 @@ defmodule XebowWeb.AnimationsLive do
 
   defp animations do
     Animation.types()
+    |> Enum.sort()
     |> Enum.map(fn animation_module ->
       name = Animation.type_name(animation_module)
 
@@ -61,6 +62,5 @@ defmodule XebowWeb.AnimationsLive do
         is_active: false
       }
     end)
-    |> Enum.sort(&(&1.name < &2.name))
   end
 end

--- a/lib/xebow_web/live/animations_live.ex
+++ b/lib/xebow_web/live/animations_live.ex
@@ -1,0 +1,48 @@
+defmodule XebowWeb.AnimationsLive do
+  @moduledoc false
+
+  alias RGBMatrix.Animation
+
+  use XebowWeb, :live_view
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    animations =
+      Animation.types()
+      |> Enum.map(fn animation_module ->
+        module_name =
+          animation_module
+          |> to_string()
+          |> String.split(".")
+          |> List.last()
+
+        id =
+          module_name
+          |> String.replace(~r/([A-Z])/, "_\\1")
+          |> String.downcase()
+          |> String.trim_leading("_")
+
+        name =
+          module_name
+          |> String.replace(~r/([A-Z])/, " \\1")
+          |> String.trim_leading()
+
+        %{
+          module: animation_module,
+          id: id,
+          name: name,
+          active: false
+        }
+      end)
+      |> Enum.sort(&(&1.name < &2.name))
+
+    socket = assign(socket, animations: animations)
+
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("toggle_animation", _params, socket) do
+    {:noreply, socket}
+  end
+end

--- a/lib/xebow_web/live/animations_live.ex
+++ b/lib/xebow_web/live/animations_live.ex
@@ -7,42 +7,31 @@ defmodule XebowWeb.AnimationsLive do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    animations =
-      Animation.types()
-      |> Enum.map(fn animation_module ->
-        module_name =
-          animation_module
-          |> to_string()
-          |> String.split(".")
-          |> List.last()
-
-        id =
-          module_name
-          |> String.replace(~r/([A-Z])/, "_\\1")
-          |> String.downcase()
-          |> String.trim_leading("_")
-
-        name =
-          module_name
-          |> String.replace(~r/([A-Z])/, " \\1")
-          |> String.trim_leading()
-
-        %{
-          module: animation_module,
-          id: id,
-          name: name,
-          active: false
-        }
-      end)
-      |> Enum.sort(&(&1.name < &2.name))
-
-    socket = assign(socket, animations: animations)
-
-    {:ok, socket}
+    {:ok, assign(socket, animations: animations())}
   end
 
   @impl Phoenix.LiveView
   def handle_event("toggle_animation", _params, socket) do
     {:noreply, socket}
+  end
+
+  defp animations do
+    Animation.types()
+    |> Enum.map(fn animation_module ->
+      name = Animation.type_name(animation_module)
+
+      id =
+        name
+        |> String.replace(" ", "_")
+        |> String.downcase()
+
+      %{
+        module: animation_module,
+        id: id,
+        name: name,
+        active: false
+      }
+    end)
+    |> Enum.sort(&(&1.name < &2.name))
   end
 end

--- a/lib/xebow_web/live/animations_live.html.leex
+++ b/lib/xebow_web/live/animations_live.html.leex
@@ -5,7 +5,7 @@
       <%= checkbox(
         :animation,
         animation.id,
-        value: animation[:active],
+        value: animation[:is_active],
         phx_click: "toggle_animation",
         phx_value_id: animation.id)
       %>

--- a/lib/xebow_web/live/animations_live.html.leex
+++ b/lib/xebow_web/live/animations_live.html.leex
@@ -1,0 +1,15 @@
+<h2>Animations</h2>
+<div class="flex flex-wrap">
+  <%= for animation <- @animations do %>
+    <div class="w-full sm:w-1/2 md:w-1/3 xl:w-1/4 mb-4">
+      <%= checkbox(
+        :animation,
+        animation.id,
+        value: animation[:active],
+        phx_click: "toggle_animation",
+        phx_value_id: animation.id)
+      %>
+      <label class="ml-1"><%= animation.name %></label>
+    </div>
+  <% end %>
+</div>

--- a/lib/xebow_web/live/animations_live.html.leex
+++ b/lib/xebow_web/live/animations_live.html.leex
@@ -1,7 +1,7 @@
 <h2>Animations</h2>
 <div class="flex flex-wrap">
   <%= for animation <- @animations do %>
-    <div class="w-full sm:w-1/2 md:w-1/3 xl:w-1/4 mb-4">
+    <div class="toggle w-full sm:w-1/2 md:w-1/3 xl:w-1/4 mb-4">
       <%= checkbox(
         :animation,
         animation.id,
@@ -9,7 +9,7 @@
         phx_click: "toggle_animation",
         phx_value_id: animation.id)
       %>
-      <label class="ml-1"><%= animation.name %></label>
+      <label><%= animation.name %></label>
     </div>
   <% end %>
 </div>

--- a/lib/xebow_web/live/matrix_live.ex
+++ b/lib/xebow_web/live/matrix_live.ex
@@ -9,26 +9,40 @@ defmodule XebowWeb.MatrixLive do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {config, config_schema} = Xebow.get_animation_config()
-    {paint_fn, config_fn, frame} = register_with_engine!()
-
     initial_assigns = [
-      leds: make_view_leds(frame),
-      config: config,
-      config_schema: config_schema
+      config: nil,
+      config_schema: nil,
+      leds: []
     ]
 
-    initial_assigns =
-      if connected?(socket) do
-        Keyword.merge(initial_assigns,
-          paint_fn: paint_fn,
-          config_fn: config_fn
-        )
-      else
-        initial_assigns
+    config_assigns =
+      case Xebow.get_animation_config() do
+        {config, config_schema} ->
+          [
+            config: config,
+            config_schema: config_schema
+          ]
+
+        nil ->
+          []
       end
 
-    {:ok, assign(socket, initial_assigns)}
+    engine_assigns =
+      if connected?(socket) do
+        {paint_fn, config_fn, frame} = register_with_engine!()
+
+        [
+          leds: make_view_leds(frame),
+          paint_fn: paint_fn,
+          config_fn: config_fn
+        ]
+      else
+        []
+      end
+
+    assigns = initial_assigns ++ config_assigns ++ engine_assigns
+
+    {:ok, assign(socket, assigns)}
   end
 
   @impl Phoenix.LiveView

--- a/lib/xebow_web/live/matrix_live.html.leex
+++ b/lib/xebow_web/live/matrix_live.html.leex
@@ -1,4 +1,4 @@
-<div class="flex mt-8 w-full">
+<div class="flex">
   <div>
     <div class="mb-1">Animation</div>
     <button class="mr-4 w-24" phx-click="previous_animation">

--- a/lib/xebow_web/live/matrix_live.html.leex
+++ b/lib/xebow_web/live/matrix_live.html.leex
@@ -7,7 +7,9 @@
     <button class="w-24" phx-click="next_animation">
       <i class="fas fa-arrow-right"></i>
     </button>
-    <%= live_component @socket, XebowWeb.AnimationConfigComponent, schema: @config_schema, config: @config %>
+    <%= if @config do %>
+      <%= live_component @socket, XebowWeb.AnimationConfigComponent, schema: @config_schema, config: @config %>
+    <% end %>
   </div>
 
   <div class="mx-auto my-24">

--- a/lib/xebow_web/router.ex
+++ b/lib/xebow_web/router.ex
@@ -18,6 +18,7 @@ defmodule XebowWeb.Router do
     pipe_through :browser
 
     live "/", MatrixLive, :index
+    live "/animations", AnimationsLive, :index
   end
 
   # Other scopes may use custom stacks.

--- a/lib/xebow_web/templates/layout/_nav.html.eex
+++ b/lib/xebow_web/templates/layout/_nav.html.eex
@@ -13,7 +13,7 @@
           <i class="fas fa-home"></i>
           Dashboard
         </a>
-        <a href="/animations" class="item">
+        <a href="<%= Routes.animations_path(@conn, :index) %>" class="item">
           <i class="fas fa-palette"></i>
           Animations
         </a>

--- a/lib/xebow_web/templates/layout/_nav.html.eex
+++ b/lib/xebow_web/templates/layout/_nav.html.eex
@@ -1,8 +1,23 @@
 <div class="flex justify-between items-center w-full py-6 border-b-2 border-gray-800 border-solid">
   <h1 class="text-4xl font-light">Xebow Studio</h1>
-  <div class="text-2xl ml-8">
+  <div class="text-2xl ml-8 select-none">
     <a href="/telemetry" title="Telemetry" target="_blank">
       <i class="fas fa-tachometer-alt"></i>
     </a>
+    <span class="dropdown">
+      <a class="button" title="Menu">
+        <i class="fas fa-bars"></i>
+      </a>
+      <div class="menu">
+        <a href="<%= Routes.matrix_path(@conn, :index) %>" class="item">
+          <i class="fas fa-home"></i>
+          Dashboard
+        </a>
+        <a href="/animations" class="item">
+          <i class="fas fa-palette"></i>
+          Animations
+        </a>
+      </div>
+    </span>
   </div>
 </div>

--- a/lib/xebow_web/templates/layout/root.html.leex
+++ b/lib/xebow_web/templates/layout/root.html.leex
@@ -10,7 +10,7 @@
     <script defer phx-track-static type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
   <body>
-    <%= render "_nav.html" %>
+    <%= render "_nav.html", conn: @conn %>
     <%= @inner_content %>
   </body>
 </html>

--- a/lib/xebow_web/templates/layout/root.html.leex
+++ b/lib/xebow_web/templates/layout/root.html.leex
@@ -11,6 +11,8 @@
   </head>
   <body>
     <%= render "_nav.html", conn: @conn %>
-    <%= @inner_content %>
+    <div class="mt-8 w-full">
+      <%= @inner_content %>
+    </div>
   </body>
 </html>

--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,8 @@ defmodule Xebow.MixProject do
       "firmware.upload": ["firmware", "upload"],
       loadconfig: [&bootstrap/1],
       upload: "upload xebow.local",
-      setup: ["deps.get", "assets.install"]
+      setup: ["deps.get", "assets.install"],
+      test: ["cmd rm -rf priv/settings_test", "test"]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Xebow.MixProject do
       version: @version,
       elixir: "~> 1.10",
       archives: [nerves_bootstrap: "~> 1.8"],
+      elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
@@ -114,6 +115,10 @@ defmodule Xebow.MixProject do
        targets: :keybow}
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def release do
     [

--- a/test/rgb_matrix/animation_test.exs
+++ b/test/rgb_matrix/animation_test.exs
@@ -1,0 +1,12 @@
+defmodule RGBMatrix.AnimationTest do
+  use ExUnit.Case
+
+  alias RGBMatrix.Animation
+
+  test "can get an animation type's human-readable name" do
+    defmodule MockAnimation.HueWave do
+    end
+
+    assert Animation.type_name(MockAnimation.HueWave) == "Hue Wave"
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -1,0 +1,37 @@
+defmodule XebowWeb.ConnCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting up a connection.
+
+  Such tests rely on `Phoenix.ConnTest` and also
+  import other functionality to make it easier
+  to build common data structures and query the data layer.
+
+  Finally, if the test case interacts with the database,
+  we enable the SQL sandbox, so changes done to the database
+  are reverted at the end of every test. If you are using
+  PostgreSQL, you can even run database tests asynchronously
+  by setting `use XebowWeb.ConnCase, async: true`, although
+  this option is not recommended for other databases.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with connections
+      import Plug.Conn
+      import Phoenix.ConnTest
+      import XebowWeb.ConnCase
+
+      alias XebowWeb.Router.Helpers, as: Routes
+
+      # The default endpoint for testing
+      @endpoint XebowWeb.Endpoint
+    end
+  end
+
+  setup _tags do
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+end

--- a/test/xebow/settings_test.exs
+++ b/test/xebow/settings_test.exs
@@ -3,6 +3,8 @@ defmodule Xebow.SettingsTest do
 
   alias Xebow.Settings
 
+  import ExUnit.CaptureLog
+
   @settings_path Application.compile_env!(:xebow, :settings_path)
 
   @animations_path Path.join(@settings_path, "animations.json")
@@ -98,7 +100,9 @@ defmodule Xebow.SettingsTest do
 
       expected_animations = [MockAnimations.Type1]
 
-      assert Settings.load_active_animations() == {:ok, expected_animations}
+      assert capture_log(fn ->
+               assert Settings.load_active_animations() == {:ok, expected_animations}
+             end) =~ "bogus.animation"
     end
   end
 end

--- a/test/xebow/settings_test.exs
+++ b/test/xebow/settings_test.exs
@@ -89,5 +89,16 @@ defmodule Xebow.SettingsTest do
 
       assert Settings.load_active_animations() == {:error, :schema_mismatch}
     end
+
+    test "load ignores invalid animations" do
+      Settings.save_active_animations!([
+        MockAnimations.Type1,
+        "bogus.animation"
+      ])
+
+      expected_animations = [MockAnimations.Type1]
+
+      assert Settings.load_active_animations() == {:ok, expected_animations}
+    end
   end
 end

--- a/test/xebow/settings_test.exs
+++ b/test/xebow/settings_test.exs
@@ -5,17 +5,88 @@ defmodule Xebow.SettingsTest do
 
   @settings_path Application.compile_env!(:xebow, :settings_path)
 
+  @animations_path Path.join(@settings_path, "animations.json")
+
+  defmodule MockAnimations.Type1 do
+  end
+
+  defmodule MockAnimations.Type2 do
+  end
+
   setup do
-    on_exit(fn -> File.rm_rf!(@settings_path) end)
+    File.mkdir_p!(@settings_path)
+    on_exit(fn -> File.rm_rf(@settings_path) end)
   end
 
   test "can create a settings directory" do
-    File.rm_rf!(@settings_path)
+    File.rm_rf(@settings_path)
 
     refute File.exists?(@settings_path)
 
     :ok = Settings.create_dir!()
 
     assert File.exists?(@settings_path)
+  end
+
+  test "can check if the animation settings file exists" do
+    refute Settings.active_animations_file_exists?()
+
+    File.write!(@animations_path, "")
+
+    assert Settings.active_animations_file_exists?()
+  end
+
+  describe "animation settings" do
+    test "can be saved" do
+      animation_types = [
+        MockAnimations.Type1,
+        MockAnimations.Type2
+      ]
+
+      expected_payload = %{
+        "schema_version" => 1,
+        "active_animation_types" => [
+          "Elixir.Xebow.SettingsTest.MockAnimations.Type1",
+          "Elixir.Xebow.SettingsTest.MockAnimations.Type2"
+        ]
+      }
+
+      Settings.save_active_animations!(animation_types)
+      assert File.exists?(@animations_path)
+
+      payload = File.read!(@animations_path) |> Jason.decode!()
+      assert payload == expected_payload
+    end
+
+    test "can be loaded" do
+      animation_types = [
+        MockAnimations.Type1,
+        MockAnimations.Type2
+      ]
+
+      Settings.save_active_animations!(animation_types)
+
+      assert Settings.load_active_animations() == {:ok, animation_types}
+    end
+
+    test "load returns error if file doesn't exist" do
+      File.rm(@animations_path)
+      refute File.exists?(@animations_path)
+
+      assert Settings.load_active_animations() == {:error, :enoent}
+    end
+
+    test "load returns error on schema version mismatch" do
+      payload =
+        %{
+          schema_version: -1,
+          active_animation_types: []
+        }
+        |> Jason.encode_to_iodata!()
+
+      File.write!(@animations_path, payload)
+
+      assert Settings.load_active_animations() == {:error, :schema_mismatch}
+    end
   end
 end

--- a/test/xebow/settings_test.exs
+++ b/test/xebow/settings_test.exs
@@ -1,0 +1,21 @@
+defmodule Xebow.SettingsTest do
+  use ExUnit.Case
+
+  alias Xebow.Settings
+
+  @settings_path Application.compile_env!(:xebow, :settings_path)
+
+  setup do
+    on_exit(fn -> File.rm_rf!(@settings_path) end)
+  end
+
+  test "can create a settings directory" do
+    File.rm_rf!(@settings_path)
+
+    refute File.exists?(@settings_path)
+
+    :ok = Settings.create_dir!()
+
+    assert File.exists?(@settings_path)
+  end
+end

--- a/test/xebow/settings_test.exs
+++ b/test/xebow/settings_test.exs
@@ -29,6 +29,7 @@ defmodule Xebow.SettingsTest do
   end
 
   test "can check if the animation settings file exists" do
+    File.rm_rf(@animations_path)
     refute Settings.active_animations_file_exists?()
 
     File.write!(@animations_path, "")

--- a/test/xebow_test.exs
+++ b/test/xebow_test.exs
@@ -1,7 +1,33 @@
 defmodule XebowTest do
   use ExUnit.Case
 
+  alias RGBMatrix.Animation
+
+  defmodule MockAnimations.Type1 do
+    use Animation
+
+    @impl Animation
+    def new(_leds, _config) do
+      nil
+    end
+
+    @impl Animation
+    def render(_state, _config) do
+      {1000, [], nil}
+    end
+  end
+
   test "has layout" do
     assert %Layout{} = Xebow.layout()
+  end
+
+  test "can get and set active animation types" do
+    animation_types = [MockAnimations.Type1]
+
+    assert Xebow.get_active_animation_types() != animation_types
+
+    Xebow.set_active_animation_types(animation_types)
+
+    assert Xebow.get_active_animation_types() == animation_types
   end
 end

--- a/test/xebow_web/live/animations_live_test.exs
+++ b/test/xebow_web/live/animations_live_test.exs
@@ -1,0 +1,13 @@
+defmodule XebowWeb.AnimationsLiveTest do
+  use XebowWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  test "shows available animations", %{conn: conn} do
+    {:ok, view, _html} = live(conn, Routes.animations_path(conn, :index))
+
+    assert view
+           |> element("#animation_breathing")
+           |> has_element?()
+  end
+end


### PR DESCRIPTION
Resolves #102 

This PR adds a page at `/animations` for a user to be able to toggle on/off the animations they want to have available when selecting animations on the dashboard. Their choices are persisted to disk and therefore survive when the device is powered off.

## Known Issues

- Trying to cycle through animations when all animations are disabled causes a crash. This is a use case we didn't account for when cycling animations. (#112)

## Screenshot

![image](https://user-images.githubusercontent.com/4755047/89718760-5c87e680-d976-11ea-9582-c012702b0195.png)
