### PR TITLE
Refactor telemetry link to use 'Routes' helper

### DIFF
--- a/lib/xebow_web/templates/layout/_nav.html.eex
+++ b/lib/xebow_web/templates/layout/_nav.html.eex
@@ -1,7 +1,7 @@
 <div class="flex justify-between items-center w-full py-6 border-b-2 border-gray-800 border-solid">
   <h1 class="text-4xl font-light">Xebow Studio</h1>
   <div class="text-2xl ml-8">
-    <a href="/telemetry" title="Telemetry" target="_blank">
+    <a href="<%= Routes.live_dashboard_path(@conn, :home) %>" title="Telemetry" target="_blank">
       <i class="fas fa-tachometer-alt"></i>
     </a>
   </div>

--- a/lib/xebow_web/templates/layout/root.html.leex
+++ b/lib/xebow_web/templates/layout/root.html.leex
@@ -10,7 +10,7 @@
     <script defer phx-track-static type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
   <body>
-    <%= render "_nav.html" %>
+    <%= render "_nav.html", conn: @conn %>
     <%= @inner_content %>
   </body>
 </html>


### PR DESCRIPTION
A small change to let the Phoenix `Routes` helper determine the telemetry path rather than hard-coding the link to `/telemetry`.