### PR TITLE
Fix Xebow crash when cycling animations and none are active

### DIFF
--- a/lib/xebow.ex
+++ b/lib/xebow.ex
@@ -184,6 +184,10 @@ defmodule Xebow do
   end
 
   @impl GenServer
+  def handle_cast(:next_animation, %State{count_of_active_animations: 0} = state) do
+    {:noreply, state}
+  end
+
   def handle_cast(:next_animation, state) do
     count_of_active_animations = state.count_of_active_animations
 
@@ -199,6 +203,10 @@ defmodule Xebow do
   end
 
   @impl GenServer
+  def handle_cast(:previous_animation, %State{count_of_active_animations: 0} = state) do
+    {:noreply, state}
+  end
+
   def handle_cast(:previous_animation, state) do
     new_index =
       case state.current_index - 1 do


### PR DESCRIPTION
This fixes the crash caused by calling `Xebow.next_animation/0` and `Xebow.previous_animation/0` when there are zero active animations.

Fixes #112 