### PR TITLE
Improve `Config` field casting, errors, and documentation

### DIFF
--- a/lib/rgb_matrix/animation/config.ex
+++ b/lib/rgb_matrix/animation/config.ex
@@ -34,8 +34,8 @@ defmodule RGBMatrix.Animation.Config do
   `:description`.
 
   The keys are defined by the first atom, the name, provided to an Animation's
-  `field` definition(s). The values are `t:RGBMatrix.Animation.Config.FieldType.t/0`
-  types.
+  `field` definition(s). The values are
+  `t:RGBMatrix.Animation.Config.FieldType.t/0` types.
 
   The documentation is optional and will be initialized to an empty list if
   omitted.
@@ -48,22 +48,14 @@ defmodule RGBMatrix.Animation.Config do
   The keys are defined by the first atom, the name, provided to an Animation's
   `field` definition(s) and must match the field being defined.
 
-  The value should be appropriate for the field.
+  The value should be appropriate for the specified field.
   """
   @type creation_params :: %{optional(atom) => FieldType.value()}
 
   @typedoc """
-  The possible error atoms during creation and update of configs
-  """
-  @type field_error ::
-          :cast_error
-          | :error
-          | :invalid_field
-          | :validation_error
-
-  @typedoc """
-  A tuple of the form `{name, FieldType.t}`, where `name` is one of the
-  valid FieldType names.
+  A tuple of the form, `{name, field}`. `name` is one of the valid
+  `FieldType` names and `field` is a
+  `t:RGBMatrix.Animation.Config.FieldType.t/0` struct.
   """
   @type schema_field :: {name :: atom, FieldType.t()}
 
@@ -83,9 +75,9 @@ defmodule RGBMatrix.Animation.Config do
   @callback update(t, %{optional(atom | String.t()) => any}) :: t
 
   @doc """
-  Returns the map of field types provided by the Config module
+  Returns a map of field types provided by the Config module
   """
-  @spec field_types :: %{atom => FieldType.field()}
+  @spec field_types :: %{atom => FieldType.submodule()}
   def field_types, do: @field_types
 
   defmacro __before_compile__(env) do
@@ -124,15 +116,15 @@ defmodule RGBMatrix.Animation.Config do
   end
 
   @doc """
-  Creates a new `%Config{}` struct belonging to the provided
+  Creates a new `t:t/0` struct belonging to the provided
   `Animation.<type>.Config` module.
 
   The provided Config must be defined through the `use Animation` and `field`
   macros in an `Animation.<type>` module.
 
-  The params provided are a map of type `t:creation_params/0`.
+  The params provided are a map of `t:creation_params/0`.
 
-  Returns a `%Config{}` struct.
+  Returns a `t:t/0` struct.
 
   Example:
       iex> module = RGBMatrix.Animation.HueWave.Config
@@ -142,6 +134,12 @@ defmodule RGBMatrix.Animation.Config do
       %RGBMatrix.Animation.HueWave.Config{direction: :up, speed: 4, width: 30}
 
   The above example shows setting the direction and width to non-default values.
+
+  Any invalid keys in the `t:creation_params/0` map will cause that param to be
+  ignored. Invalid values for fields will be ignored. In both cases, the default
+  provided to the type will be used as the initial value for that field.
+
+  All errors will be logged.
   """
   @spec new_config(
           module :: module,
@@ -149,21 +147,23 @@ defmodule RGBMatrix.Animation.Config do
           params :: creation_params
         ) :: t
   def new_config(module, schema, params) do
-    schema
-    |> Enum.map(fn schema_field -> validate_field(schema_field, params) end)
-    |> Map.new()
-    |> create_struct!(module)
+    schema =
+      schema
+      |> Enum.map(fn schema_field -> validate_field(schema_field, params) end)
+      |> Map.new()
+
+    struct!(module, schema)
   end
 
   @doc """
-  Updates the provided `%Config{}` struct using the provided schema and params.
+  Updates the provided `t:t/0` struct using the provided schema and params.
 
-  The params are a map of type `t:update_params/0`.
+  The params are a map of `t:update_params/0`.
 
   Configs must be retrieved through the use of `Xebow.get_animation_config/0`,
   which will return both the config and the schema.
 
-  Returns the updated `%Config{}` struct.
+  Returns the updated `t:t/0` struct.
 
   Example:
       iex> {config, schema} = Xebow.get_animation_config()
@@ -172,6 +172,9 @@ defmodule RGBMatrix.Animation.Config do
       %RGBMatrix.Animation.HueWave.Config{direction: :left, speed: 8, width: 20}
 
   The above example shows updating the direction and speed.
+
+  Any errors encountered during update are logged, and the struct is returned
+  unchanged.
   """
   @spec update_config(
           config :: t,
@@ -191,64 +194,67 @@ defmodule RGBMatrix.Animation.Config do
           schema :: config_schema
         ) :: t
   defp cast_and_update_field({key, value} = _param, config, schema) do
-    with key <- create_atom_key(key),
-         {:ok, %type_module{} = type} <- Keyword.fetch(schema, key),
+    with {:ok, key} <- create_atom_key(key),
+         {:ok, %type_module{} = type} <- fetch_type_from_schema(schema, key),
          {:ok, value} <- type_module.cast(type, value) do
       Map.put(config, key, value)
     else
-      error ->
-        field_warn(error, key, value)
+      {:error, reason} ->
+        field_warn(reason, key, value)
         config
     end
   end
 
-  @spec validate_field(schema_field, creation_params) ::
-          {atom, FieldType.field()} | nil
-  defp validate_field({key, %type_module{} = type} = _field, params) do
+  @spec validate_field(schema_field, creation_params) :: {atom, FieldType.value()}
+  defp validate_field({key, %type_module{} = type} = _schema_field, params) do
     value = Map.get(params, key, type.default)
 
     case type_module.validate(type, value) do
       :ok ->
         {key, value}
 
-      error ->
-        field_warn(error, key, value)
+      {:error, reason} ->
+        field_warn(reason, key, value)
         {key, type.default}
     end
   end
 
-  @spec create_atom_key(key :: atom | String.t()) ::
-          (key :: atom) | :invalid_field
-  defp create_atom_key(key) when is_atom(key), do: key
+  @spec create_atom_key(key :: atom) ::
+          {:ok, key :: atom} | {:error, :undefined_field}
+  defp create_atom_key(key) when is_atom(key), do: {:ok, key}
 
+  @spec create_atom_key(key :: String.t()) ::
+          {:ok, key :: atom} | {:error, :undefined_field}
   defp create_atom_key(key) when is_binary(key) do
-    String.to_existing_atom(key)
+    {:ok, String.to_existing_atom(key)}
   rescue
     ArgumentError ->
-      :invalid_field
+      {:error, :undefined_field}
   end
 
-  @spec create_struct!(map, module) :: struct
-  defp create_struct!(map, module), do: struct!(module, map)
+  @spec fetch_type_from_schema(config_schema, atom) ::
+          {:ok, FieldType.t()} | {:error, :undefined_field}
+  defp fetch_type_from_schema(schema, key) do
+    case Keyword.fetch(schema, key) do
+      {:ok, type} -> {:ok, type}
+      :error -> {:error, :undefined_field}
+    end
+  end
 
   @spec field_warn(
-          error :: field_error,
+          reason :: FieldType.error(),
           key :: atom | String.t(),
           value :: any
         ) :: :ok
-  defp field_warn(:cast_error, key, value) do
+  defp field_warn(:wrong_type, key, value) do
     Logger.warn("#{inspect(value)} is not the correct type for #{key}")
   end
 
-  defp field_warn(:error, key, _value) do
-    Logger.warn("#{inspect(key)} is an invalid field identifier")
+  defp field_warn(:undefined_field, key, _value) do
+    Logger.warn("#{inspect(key)} is an undefined field identifier")
   end
 
-  defp field_warn(:invalid_field, key, _value) do
-    Logger.warn("#{inspect(key)} is an invalid field identifier")
-  end
-
-  defp field_warn(:validation_error, key, value) do
+  defp field_warn(:invalid_value, key, value) do
     Logger.warn("#{inspect(value)} is an invalid value for #{key}")
   end
 end

--- a/lib/rgb_matrix/animation/config.ex
+++ b/lib/rgb_matrix/animation/config.ex
@@ -3,25 +3,80 @@ defmodule RGBMatrix.Animation.Config do
   Provides a behaviour and macros for defining animation configurations.
   """
 
+  alias __MODULE__.FieldType
+
+  require Logger
+
+  @field_types %{
+    integer: FieldType.Integer,
+    option: FieldType.Option
+  }
+
   @typedoc """
-  An animation config is a struct, but we don't know ahead of time all the
+  A `Config` is a struct representing a config for a specific animation.
   concrete types of struct it might be. (e.g.:
   RGBMatrix.Animation.HueWave.Config.t)
   """
   @type t :: struct
-  @type field_type :: [
-          __MODULE__.FieldType.Integer
-          | __MODULE__.FieldType.Option
-        ]
 
-  @callback schema() :: keyword(any)
-  @callback new(%{optional(atom) => any}) :: t
-  @callback update(t, %{optional(atom) => any}) :: t
+  @typedoc """
+  A `config_schema` is a keyword list containing the configuration fields for
+  an animation type.
 
-  @field_types %{
-    integer: __MODULE__.FieldType.Integer,
-    option: __MODULE__.FieldType.Option
-  }
+  It provides the defaults for each field, the available
+  parameters to configure (such as `:default`, `:min`, `:options`, and so on),
+  and can provide `:doc`, a keyword list, for documentation such as a
+  human-readable `:name` and `:description`.
+
+  The keys are defined by the first atom provided to an Animation's `field`
+  definition(s). The values are `Config.FieldType` types.
+
+  The documentation is not guaranteed to exist. It will be an empty list, in
+  that case.
+  """
+  @type config_schema :: keyword(FieldType.t())
+
+  @typedoc """
+  `creation_params` is a map used during creation of an
+  `Animation.<type>.Config`.
+
+  The keys are defined by the first atom provided to an Animation's `field`
+  definition(s) and must be one of `#{inspect(Map.keys(@field_types))}`.
+
+  The value should be appropriate for the field.
+  """
+  @type creation_params :: %{optional(atom) => FieldType.value()}
+
+  @typedoc """
+  The possible error atoms during creation and update of configs
+  """
+  @type field_error ::
+          :cast_error
+          | :error
+          | :invalid_field
+          | :validation_error
+
+  @typedoc """
+  A `schema_field` is a tuple of the form `{name, %FieldType.t}`.
+
+  `name` is one of `#{inspect(Map.keys(@field_types))}`
+  """
+  @type schema_field :: {name :: atom, FieldType.t()}
+
+  @typedoc """
+  `update_params` is a map used to update an `Animation.<type>.Config`.
+
+  The key is defined by the first atom provided to an Animation's `field`
+  definition(s) and must be one of `#{inspect(Map.keys(@field_types))}`.
+  The key may be a string or an atom.
+
+  The value should be appropriate for the field.
+  """
+  @type update_params :: %{(atom | String.t()) => any}
+
+  @callback schema() :: config_schema
+  @callback new(%{optional(atom) => FieldType.value()}) :: t
+  @callback update(t, %{optional(atom | String.t()) => any}) :: t
 
   @doc """
   Returns the map of field types provided by the Config module
@@ -65,8 +120,8 @@ defmodule RGBMatrix.Animation.Config do
   end
 
   @doc """
-  Creates a new %Config{} struct belonging to the provided Animation.<type>.Config
-  module.
+  Creates a new %Config{} struct belonging to the provided
+  `Animation.<type>.Config` module.
 
   The provided Config must be defined through the `use Animation` and `field`
   macros in an Animation.<type> module.
@@ -77,14 +132,18 @@ defmodule RGBMatrix.Animation.Config do
       iex> RGBMatrix.Animation.Config.new_config(
       ...>   RGBMatrix.Animation.HueWave.Config,
       ...>   RGBMatrix.Animation.HueWave.Config.schema(),
-      ...>   %{}
-      ...> )
+      ...>   %{})
       %RGBMatrix.Animation.HueWave.Config{direction: :right, speed: 4, width: 20}
   """
-  @spec new_config(module :: module, schema :: any, params :: map) :: t
+  @spec new_config(
+          module :: module,
+          schema :: config_schema,
+          params :: creation_params
+        ) :: t
   def new_config(module, schema, params) do
     schema
-    |> Map.new(&validate_field(&1, params))
+    |> Enum.map(fn schema_field -> validate_field(schema_field, params) end)
+    |> Map.new()
     |> create_struct!(module)
   end
 
@@ -97,42 +156,85 @@ defmodule RGBMatrix.Animation.Config do
       iex> RGBMatrix.Animation.Config.update_config(
       ...>   hue_wave_config,
       ...>   RGBMatrix.Animation.HueWave.Config.schema(),
-      ...>   %{"direction" => "left"}
-      ...> )
+      ...>   %{"direction" => "left"})
       %RGBMatrix.Animation.HueWave.Config{direction: :left, speed: 4, width: 20}
   """
-  @spec update_config(config :: t, schema :: any, params :: map) :: t
+  @spec update_config(
+          config :: t,
+          schema :: config_schema,
+          params :: update_params
+        ) :: t
   def update_config(config, schema, params) do
-    Enum.reduce(params, config, &update_field(&1, &2, schema))
+    params
+    |> Enum.reduce(config, fn param, config ->
+      cast_and_update_field(param, config, schema)
+    end)
   end
 
-  defp create_atom_key(key) when is_binary(key), do: String.to_existing_atom(key)
-  defp create_atom_key(key) when is_atom(key), do: key
-
-  defp create_struct!(map, module), do: struct!(module, map)
-
-  defp update_field({key, value}, config, schema) do
-    key = create_atom_key(key)
-
-    %type_module{} = type = Keyword.fetch!(schema, key)
-    {:ok, value} = type_module.cast(type, value)
-    if type_module.validate(type, value) == :error, do: value_error!(value, key)
-
-    Map.put(config, key, value)
-  end
-
-  defp validate_field({key, %type_module{} = type}, params) do
-    value = Map.get(params, key, type.default)
-
-    case type_module.validate(type, value) do
-      :ok -> {key, value}
-      :error -> value_error!(value, key)
+  @spec cast_and_update_field(
+          param :: {atom | String.t(), any},
+          config :: t,
+          schema :: config_schema
+        ) :: t
+  defp cast_and_update_field({key, value} = _param, config, schema) do
+    with key <- create_atom_key(key),
+         {:ok, %type_module{} = type} <- Keyword.fetch(schema, key),
+         {:ok, value} <- type_module.cast(type, value) do
+      Map.put(config, key, value)
+    else
+      error ->
+        field_warn(error, key, value)
+        config
     end
   end
 
-  defp value_error!(value, key) do
-    message = "#{__MODULE__}: value `#{inspect(value)}` is invalid for config option `#{key}`."
+  @spec validate_field(schema_field, creation_params) ::
+          {atom, FieldType.field()} | nil
+  defp validate_field({key, %type_module{} = type} = _field, params) do
+    value = Map.get(params, key, type.default)
 
-    raise ArgumentError, message: message
+    case type_module.validate(type, value) do
+      :ok ->
+        {key, value}
+
+      error ->
+        field_warn(error, key, value)
+        {key, type.default}
+    end
+  end
+
+  @spec create_atom_key(key :: atom | String.t()) ::
+          (key :: atom) | :invalid_field
+  defp create_atom_key(key) when is_atom(key), do: key
+
+  defp create_atom_key(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError ->
+      :invalid_field
+  end
+
+  @spec create_struct!(map, module) :: struct
+  defp create_struct!(map, module), do: struct!(module, map)
+
+  @spec field_warn(
+          error :: field_error,
+          key :: atom | String.t(),
+          value :: any
+        ) :: :ok
+  defp field_warn(:cast_error, key, value) do
+    Logger.warn("#{inspect(value)} is not the correct type for #{key}")
+  end
+
+  defp field_warn(:error, key, _value) do
+    Logger.warn("#{inspect(key)} is an invalid field identifier")
+  end
+
+  defp field_warn(:invalid_field, key, _value) do
+    Logger.warn("#{inspect(key)} is an invalid field identifier")
+  end
+
+  defp field_warn(:validation_error, key, value) do
+    Logger.warn("#{inspect(value)} is an invalid value for #{key}")
   end
 end

--- a/lib/rgb_matrix/animation/config/field_type.ex
+++ b/lib/rgb_matrix/animation/config/field_type.ex
@@ -3,24 +3,31 @@ defmodule RGBMatrix.Animation.Config.FieldType do
   Provides a behaviour for defining animation configuration field types.
   """
 
-  @type t ::
-          __MODULE__.Integer.t()
-          | __MODULE__.Option.t()
+  @typedoc """
+  A field struct, containing all defined config information for that specific
+  field.
+  """
+  @type t :: __MODULE__.Integer.t() | __MODULE__.Option.t()
 
   @typedoc """
-  `field` is a union of all the `FieldType.<field_type>` modules
+  The possible error atoms during validation and update of configs
   """
-  @type field ::
-          __MODULE__.Integer
-          | __MODULE__.Option
+  @type error ::
+          :invalid_value
+          | :undefined_field
+          | :wrong_type
 
   @typedoc """
-  `value` is a union of all valid field value types
+  Module names for defined field types
   """
-  @type value ::
-          __MODULE__.Integer.value()
-          | __MODULE__.Option.value()
+  @type submodule :: __MODULE__.Integer | __MODULE__.Option
 
-  @callback validate(t, value) :: :ok | :validation_error
-  @callback cast(t, any) :: {:ok, value} | :cast_error | :validation_error
+  @typedoc """
+  A value which is appropriate for a defined field and does not require casting
+  to be used for config creation or update.
+  """
+  @type value :: __MODULE__.Integer.value() | __MODULE__.Option.value()
+
+  @callback validate(t, value) :: :ok | {:error, :invalid_value}
+  @callback cast(t, any) :: {:ok, value} | {:error, :wrong_type | :invalid_value}
 end

--- a/lib/rgb_matrix/animation/config/field_type.ex
+++ b/lib/rgb_matrix/animation/config/field_type.ex
@@ -7,6 +7,20 @@ defmodule RGBMatrix.Animation.Config.FieldType do
           __MODULE__.Integer.t()
           | __MODULE__.Option.t()
 
-  @callback validate(t, any) :: :ok | :error
-  @callback cast(t, any) :: {:ok, any} | :error
+  @typedoc """
+  `field` is a union of all the `FieldType.<field_type>` modules
+  """
+  @type field ::
+          __MODULE__.Integer
+          | __MODULE__.Option
+
+  @typedoc """
+  `value` is a union of all valid field value types
+  """
+  @type value ::
+          __MODULE__.Integer.value()
+          | __MODULE__.Option.value()
+
+  @callback validate(t, value) :: :ok | :validation_error
+  @callback cast(t, any) :: {:ok, value} | :cast_error | :validation_error
 end

--- a/lib/rgb_matrix/animation/config/field_type/integer.ex
+++ b/lib/rgb_matrix/animation/config/field_type/integer.ex
@@ -3,6 +3,21 @@ defmodule RGBMatrix.Animation.Config.FieldType.Integer do
   An integer field type for use in animation configuration.
 
   Supports defining a minimum and a maximum, as well as a step value.
+
+  To define an integer field in an animation, specify `:integer` as the field
+  type.
+
+  Example:
+      field :speed, :integer,
+        default: 4,
+        min: 0,
+        max: 32,
+        doc: [
+          name: "Speed",
+          description: \"""
+          Controls the speed at which the wave moves across the matrix.
+          \"""
+        ]
   """
 
   @behaviour RGBMatrix.Animation.Config.FieldType
@@ -19,27 +34,30 @@ defmodule RGBMatrix.Animation.Config.FieldType.Integer do
           max: integer,
           doc: keyword(String.t()) | []
         }
+  @type value :: integer
 
   @impl true
-  @spec validate(field_type :: t, value :: integer) :: :ok | :error
+  @spec validate(field_type :: t, value) :: :ok | :validation_error
   def validate(field_type, value) do
     if value >= field_type.min &&
          value <= field_type.max &&
-         mod(value, field_type.step) == 0 do
+         mod(value - field_type.min, field_type.step) == 0 do
       :ok
     else
-      :error
+      :validation_error
     end
   end
 
   @impl true
-  @spec cast(field_type :: t, value :: any) :: {:ok, integer} | :error
+  @spec cast(field_type :: t, any) ::
+          {:ok, value} | :cast_error | :validation_error
   def cast(field_type, value) do
     with {:ok, casted_value} <- do_cast(value),
          :ok <- validate(field_type, casted_value) do
       {:ok, casted_value}
     else
-      :error -> :error
+      :validation_error = e -> e
+      :error -> :cast_error
     end
   end
 

--- a/lib/rgb_matrix/animation/config/field_type/option.ex
+++ b/lib/rgb_matrix/animation/config/field_type/option.ex
@@ -4,7 +4,7 @@ defmodule RGBMatrix.Animation.Config.FieldType.Option do
 
   Supports defining a list of pre-defined options as atoms.
 
-  To define an integer field in an animation, specify `:integer` as the field
+  To define an option field in an animation, specify `:option` as the field
   type.
 
   Example:

--- a/lib/rgb_matrix/animation/config/field_type/option.ex
+++ b/lib/rgb_matrix/animation/config/field_type/option.ex
@@ -3,6 +3,28 @@ defmodule RGBMatrix.Animation.Config.FieldType.Option do
   An option field type for use in animation configuration.
 
   Supports defining a list of pre-defined options as atoms.
+
+  To define an integer field in an animation, specify `:integer` as the field
+  type.
+
+  Example:
+      field :direction, :option,
+        default: :right,
+        options: ~w(right left up down)a, # This must be a list of atoms
+        doc: [
+          name: "Direction",
+          description: \"""
+          Controls the direction of the wave
+          \"""
+        ]
+
+        # Also valid:
+        options: [
+          :right,
+          :left,
+          :up,
+          :down
+        ]
   """
 
   @behaviour RGBMatrix.Animation.Config.FieldType
@@ -16,34 +38,35 @@ defmodule RGBMatrix.Animation.Config.FieldType.Option do
           options: [atom],
           doc: keyword(String.t()) | []
         }
+  @type value :: atom
 
   @impl true
-  @spec validate(field_type :: t, value :: atom) :: :ok | :error
-  def validate(%__MODULE__{options: options}, value) do
+  @spec validate(field_type :: t, value) :: :ok | :validation_error
+  def validate(%__MODULE__{options: options} = _field_type, value) do
     if value in options do
       :ok
     else
-      :error
+      :validation_error
     end
   end
 
   @impl true
-  @spec cast(field_type :: t, value :: any) :: {:ok, atom} | :error
+  @spec cast(field_type :: t, any) ::
+          {:ok, value} | :cast_error | :validation_error
   def cast(field_type, value) do
     with {:ok, casted_value} <- do_cast(value),
          :ok <- validate(field_type, casted_value) do
       {:ok, casted_value}
     else
-      :error -> :error
+      :validation_error = e -> e
+      :error -> :cast_error
     end
   end
 
   defp do_cast(binary_value) when is_binary(binary_value) do
-    try do
-      {:ok, String.to_existing_atom(binary_value)}
-    rescue
-      ArgumentError -> :error
-    end
+    {:ok, String.to_existing_atom(binary_value)}
+  rescue
+    ArgumentError -> :error
   end
 
   defp do_cast(value) when is_atom(value), do: {:ok, value}

--- a/lib/rgb_matrix/animation/config/field_type/option.ex
+++ b/lib/rgb_matrix/animation/config/field_type/option.ex
@@ -18,7 +18,7 @@ defmodule RGBMatrix.Animation.Config.FieldType.Option do
           \"""
         ]
 
-        # Also valid:
+        # This options list produces the same result as above:
         options: [
           :right,
           :left,
@@ -41,25 +41,25 @@ defmodule RGBMatrix.Animation.Config.FieldType.Option do
   @type value :: atom
 
   @impl true
-  @spec validate(field_type :: t, value) :: :ok | :validation_error
+  @spec validate(field_type :: t, value) :: :ok | {:error, :invalid_value}
   def validate(%__MODULE__{options: options} = _field_type, value) do
     if value in options do
       :ok
     else
-      :validation_error
+      {:error, :invalid_value}
     end
   end
 
   @impl true
   @spec cast(field_type :: t, any) ::
-          {:ok, value} | :cast_error | :validation_error
+          {:ok, value} | {:error, :wrong_type | :invalid_value}
   def cast(field_type, value) do
     with {:ok, casted_value} <- do_cast(value),
          :ok <- validate(field_type, casted_value) do
       {:ok, casted_value}
     else
-      :validation_error = e -> e
-      :error -> :cast_error
+      {:error, :invalid_value} = e -> e
+      :error -> {:error, :wrong_type}
     end
   end
 

--- a/test/rgb_matrix/animation/config/field_type/integer_test.exs
+++ b/test/rgb_matrix/animation/config/field_type/integer_test.exs
@@ -21,12 +21,13 @@ defmodule IntegerTest do
       assert Integer.validate(context.test_integer, 3) == :ok
     end
 
-    test "receives invalid step-multiple input and returns `:validation_error`", context do
-      assert Integer.validate(context.test_integer, 4) == :validation_error
+    test "receives invalid step-multiple input and returns `{:error, :invalid_value}`", context do
+      assert Integer.validate(context.test_integer, 4) == {:error, :invalid_value}
     end
 
-    test "receives invalid out-of-range input and returns `:validation_error`", context do
-      assert Integer.validate(context.test_integer, 13) == :validation_error
+    test "receives invalid out-of-range input and returns `{:error, :invalid_value}`", context do
+      assert Integer.validate(context.test_integer, 13) == {:error, :invalid_value}
+      assert Integer.validate(context.test_integer, -1) == {:error, :invalid_value}
     end
   end
 
@@ -37,31 +38,26 @@ defmodule IntegerTest do
       assert Integer.cast(context.test_integer, "7") == {:ok, 7}
     end
 
-    test "receives valid integer input and returns `{:ok, <value}`", context do
+    test "receives valid integer input and returns `{:ok, <value>}`", context do
       assert Integer.cast(context.test_integer, 7) == {:ok, 7}
     end
 
-    test "receives float string input and returns the integer part only", context do
-      assert Integer.cast(context.test_integer, "1.0") == {:ok, 1}
+    test "receives invalid input and returns `{:error, :wrong_type}`", context do
+      assert Integer.cast(context.test_integer, "2.") == {:error, :wrong_type}
+      assert Integer.cast(context.test_integer, "1.0") == {:error, :wrong_type}
+      assert Integer.cast(context.test_integer, 9.0) == {:error, :wrong_type}
+      assert Integer.cast(context.test_integer, "fish") == {:error, :wrong_type}
+      assert Integer.cast(context.test_integer, %{value: 4}) == {:error, :wrong_type}
     end
 
-    test "receives float input and returns the integer part only", context do
-      assert Integer.cast(context.test_integer, 9.0) == {:ok, 9}
-    end
-
-    test "receives invalid input and returns `:cast_error`", context do
-      assert Integer.cast(context.test_integer, "fish") == :cast_error
-      assert Integer.cast(context.test_integer, %{value: 4}) == :cast_error
-    end
-
-    test "receives integer string input that is invalid for the field definition and returns `:validation_error`",
+    test "receives integer string input that is invalid for the field definition and returns `{:error, :invalid_value}`",
          context do
-      assert Integer.cast(context.test_integer, "4") == :validation_error
+      assert Integer.cast(context.test_integer, "4") == {:error, :invalid_value}
     end
 
-    test "receives integer input that is invalid for the field definition and returns `:validation_error`",
+    test "receives integer input that is invalid for the field definition and returns `{:error, :invalid_value}`",
          context do
-      assert Integer.cast(context.test_integer, 6) == :validation_error
+      assert Integer.cast(context.test_integer, 6) == {:error, :invalid_value}
     end
   end
 end

--- a/test/rgb_matrix/animation/config/field_type/integer_test.exs
+++ b/test/rgb_matrix/animation/config/field_type/integer_test.exs
@@ -1,0 +1,67 @@
+defmodule IntegerTest do
+  use ExUnit.Case
+
+  alias RGBMatrix.Animation.Config.FieldType.Integer
+
+  defp test_integer(_context) do
+    [
+      test_integer: %Integer{
+        default: 5,
+        min: 1,
+        max: 11,
+        step: 2
+      }
+    ]
+  end
+
+  describe "Integer field type function `validate/2`" do
+    setup :test_integer
+
+    test "receives valid integer input and returns `:ok`", context do
+      assert Integer.validate(context.test_integer, 3) == :ok
+    end
+
+    test "receives invalid step-multiple input and returns `:validation_error`", context do
+      assert Integer.validate(context.test_integer, 4) == :validation_error
+    end
+
+    test "receives invalid out-of-range input and returns `:validation_error`", context do
+      assert Integer.validate(context.test_integer, 13) == :validation_error
+    end
+  end
+
+  describe "Integer field type function `cast/2`" do
+    setup :test_integer
+
+    test "receives valid string input and returns `{:ok, <value>}`", context do
+      assert Integer.cast(context.test_integer, "7") == {:ok, 7}
+    end
+
+    test "receives valid integer input and returns `{:ok, <value}`", context do
+      assert Integer.cast(context.test_integer, 7) == {:ok, 7}
+    end
+
+    test "receives float string input and returns the integer part only", context do
+      assert Integer.cast(context.test_integer, "1.0") == {:ok, 1}
+    end
+
+    test "receives float input and returns the integer part only", context do
+      assert Integer.cast(context.test_integer, 9.0) == {:ok, 9}
+    end
+
+    test "receives invalid input and returns `:cast_error`", context do
+      assert Integer.cast(context.test_integer, "fish") == :cast_error
+      assert Integer.cast(context.test_integer, %{value: 4}) == :cast_error
+    end
+
+    test "receives integer string input that is invalid for the field definition and returns `:validation_error`",
+         context do
+      assert Integer.cast(context.test_integer, "4") == :validation_error
+    end
+
+    test "receives integer input that is invalid for the field definition and returns `:validation_error`",
+         context do
+      assert Integer.cast(context.test_integer, 6) == :validation_error
+    end
+  end
+end

--- a/test/rgb_matrix/animation/config/field_type/option_test.exs
+++ b/test/rgb_matrix/animation/config/field_type/option_test.exs
@@ -1,0 +1,49 @@
+defmodule OptionTest do
+  use ExUnit.Case
+
+  alias RGBMatrix.Animation.Config.FieldType.Option
+
+  defp test_option(_context) do
+    [
+      test_option: %Option{
+        default: :default,
+        options: ~w(default non_default valid)a
+      }
+    ]
+  end
+
+  describe "Option field type function `validate/2`" do
+    setup :test_option
+
+    test "receives valid atoms for input and returns `:ok`", context do
+      assert Option.validate(context.test_option, :default) == :ok
+      assert Option.validate(context.test_option, :non_default) == :ok
+      assert Option.validate(context.test_option, :valid) == :ok
+    end
+
+    test "receives invalid atoms and returns `:validation_error`", context do
+      assert Option.validate(context.test_option, :invalid) == :validation_error
+    end
+  end
+
+  describe "Option field type function `cast/2`" do
+    setup :test_option
+
+    test "receives valid string input and returns `{:ok, <value>}`", context do
+      assert Option.cast(context.test_option, "default") == {:ok, :default}
+      assert Option.cast(context.test_option, "valid") == {:ok, :valid}
+    end
+
+    test "receives valid atom input and returns `{:ok, <value>}`", context do
+      assert Option.cast(context.test_option, :non_default) == {:ok, :non_default}
+    end
+
+    test "receives invalid string input and returns `:cast_error`", context do
+      assert Option.cast(context.test_option, "floop") == :cast_error
+    end
+
+    test "receives invalid atom input and returns `:validation_error`", context do
+      assert Option.cast(context.test_option, :random_atom) == :validation_error
+    end
+  end
+end

--- a/test/rgb_matrix/animation/config/field_type/option_test.exs
+++ b/test/rgb_matrix/animation/config/field_type/option_test.exs
@@ -22,7 +22,7 @@ defmodule OptionTest do
     end
 
     test "receives invalid atoms and returns `:validation_error`", context do
-      assert Option.validate(context.test_option, :invalid) == :validation_error
+      assert Option.validate(context.test_option, :bad_option) == {:error, :invalid_value}
     end
   end
 
@@ -38,12 +38,12 @@ defmodule OptionTest do
       assert Option.cast(context.test_option, :non_default) == {:ok, :non_default}
     end
 
-    test "receives invalid string input and returns `:cast_error`", context do
-      assert Option.cast(context.test_option, "floop") == :cast_error
+    test "receives invalid string input and returns `{:error, :wrong_type}`", context do
+      assert Option.cast(context.test_option, "floop") == {:error, :wrong_type}
     end
 
-    test "receives invalid atom input and returns `:validation_error`", context do
-      assert Option.cast(context.test_option, :random_atom) == :validation_error
+    test "receives invalid atom input and returns `{:error, :invalid_value}`", context do
+      assert Option.cast(context.test_option, :random_atom) == {:error, :invalid_value}
     end
   end
 end

--- a/test/rgb_matrix/animation/config_test.exs
+++ b/test/rgb_matrix/animation/config_test.exs
@@ -170,7 +170,7 @@ defmodule ConfigTest do
                  ) == context.test_config
         end)
 
-      assert output =~ ":invalid_option is an invalid field identifier"
+      assert output =~ ":invalid_option is an undefined field identifier"
     end
 
     test "will not update with option choices that have not been defined for that field",


### PR DESCRIPTION
This updates the `Config` and `FieldType` modules and submodules.

`Config` handles errors returned by field type casting and validation functions and prints a Logger warning about the error. State is returned unchanged when an error occurs.

For field types, both casting and validation operations now return errors on invalid input, instead of crashing.

Added some documentation for the `Config` module and for the `Integer` and `Option` field type modules. Please check that what I put in was accurate/correct.

I also improved the `Config` tests, and added tests for both `Integer` and `Option` field types.

Fixes #70 