### PR TITLE
Only advertise the web interface as a network service

### DIFF
--- a/config/keybow/config.exs
+++ b/config/keybow/config.exs
@@ -64,22 +64,10 @@ config :mdns_lite,
   # Advertise the following services over mDNS.
   services: [
     %{
-      name: "SSH Remote Login Protocol",
-      protocol: "ssh",
+      name: "Xebow Web Interface",
+      protocol: "http",
       transport: "tcp",
-      port: 22
-    },
-    %{
-      name: "Secure File Transfer Protocol over SSH",
-      protocol: "sftp-ssh",
-      transport: "tcp",
-      port: 22
-    },
-    %{
-      name: "Erlang Port Mapper Daemon",
-      protocol: "epmd",
-      transport: "tcp",
-      port: 4369
+      port: 80
     }
   ]
 


### PR DESCRIPTION
This PR updates the network services that Xebow advertises (via mDNS). It is now only advertising the web interface to other devices on the network. The SSH, SFTP, and Erlang port mapper have been removed from being advertised because it is unlikely that a non-developer would need to auto-discover these. Note that `ssh xebow.local` and `mix upload` still work fine; this PR only adjusts the service broadcasts that Xebow sends out to other devices on the network.