### PR TITLE
Define keys and LEDs in target config

### DIFF
--- a/config/host/config.exs
+++ b/config/host/config.exs
@@ -1,33 +1,35 @@
 import Config
 
 config :xebow,
-  leds: [
-    %{id: :l001, x: 0, y: 0},
-    %{id: :l002, x: 1, y: 0},
-    %{id: :l003, x: 2, y: 0},
-    %{id: :l004, x: 0, y: 1},
-    %{id: :l005, x: 1, y: 1},
-    %{id: :l006, x: 2, y: 1},
-    %{id: :l007, x: 0, y: 2},
-    %{id: :l008, x: 1, y: 2},
-    %{id: :l009, x: 2, y: 2},
-    %{id: :l010, x: 0, y: 3},
-    %{id: :l011, x: 1, y: 3},
-    %{id: :l012, x: 2, y: 3}
-  ],
-  keys: [
-    %{id: :k001, x: 0, y: 0, opts: [led: :l001]},
-    %{id: :k002, x: 1, y: 0, opts: [led: :l002]},
-    %{id: :k003, x: 2, y: 0, opts: [led: :l003]},
-    %{id: :k004, x: 0, y: 1, opts: [led: :l004]},
-    %{id: :k005, x: 1, y: 1, opts: [led: :l005]},
-    %{id: :k006, x: 2, y: 1, opts: [led: :l006]},
-    %{id: :k007, x: 0, y: 2, opts: [led: :l007]},
-    %{id: :k008, x: 1, y: 2, opts: [led: :l008]},
-    %{id: :k009, x: 2, y: 2, opts: [led: :l009]},
-    %{id: :k010, x: 0, y: 3, opts: [led: :l010]},
-    %{id: :k011, x: 1, y: 3, opts: [led: :l011]},
-    %{id: :k012, x: 2, y: 3, opts: [led: :l012]}
+  layout: [
+    leds: [
+      %{id: :l001, x: 0, y: 0},
+      %{id: :l002, x: 1, y: 0},
+      %{id: :l003, x: 2, y: 0},
+      %{id: :l004, x: 0, y: 1},
+      %{id: :l005, x: 1, y: 1},
+      %{id: :l006, x: 2, y: 1},
+      %{id: :l007, x: 0, y: 2},
+      %{id: :l008, x: 1, y: 2},
+      %{id: :l009, x: 2, y: 2},
+      %{id: :l010, x: 0, y: 3},
+      %{id: :l011, x: 1, y: 3},
+      %{id: :l012, x: 2, y: 3}
+    ],
+    keys: [
+      %{id: :k001, x: 0, y: 0, opts: [led: :l001]},
+      %{id: :k002, x: 1, y: 0, opts: [led: :l002]},
+      %{id: :k003, x: 2, y: 0, opts: [led: :l003]},
+      %{id: :k004, x: 0, y: 1, opts: [led: :l004]},
+      %{id: :k005, x: 1, y: 1, opts: [led: :l005]},
+      %{id: :k006, x: 2, y: 1, opts: [led: :l006]},
+      %{id: :k007, x: 0, y: 2, opts: [led: :l007]},
+      %{id: :k008, x: 1, y: 2, opts: [led: :l008]},
+      %{id: :k009, x: 2, y: 2, opts: [led: :l009]},
+      %{id: :k010, x: 0, y: 3, opts: [led: :l010]},
+      %{id: :k011, x: 1, y: 3, opts: [led: :l011]},
+      %{id: :k012, x: 2, y: 3, opts: [led: :l012]}
+    ]
   ]
 
 import_config "#{Mix.env()}.exs"

--- a/config/host/config.exs
+++ b/config/host/config.exs
@@ -1,3 +1,33 @@
 import Config
 
+config :xebow,
+  leds: [
+    %{id: :l001, x: 0, y: 0},
+    %{id: :l002, x: 1, y: 0},
+    %{id: :l003, x: 2, y: 0},
+    %{id: :l004, x: 0, y: 1},
+    %{id: :l005, x: 1, y: 1},
+    %{id: :l006, x: 2, y: 1},
+    %{id: :l007, x: 0, y: 2},
+    %{id: :l008, x: 1, y: 2},
+    %{id: :l009, x: 2, y: 2},
+    %{id: :l010, x: 0, y: 3},
+    %{id: :l011, x: 1, y: 3},
+    %{id: :l012, x: 2, y: 3}
+  ],
+  keys: [
+    %{id: :k001, x: 0, y: 0, opts: [led: :l001]},
+    %{id: :k002, x: 1, y: 0, opts: [led: :l002]},
+    %{id: :k003, x: 2, y: 0, opts: [led: :l003]},
+    %{id: :k004, x: 0, y: 1, opts: [led: :l004]},
+    %{id: :k005, x: 1, y: 1, opts: [led: :l005]},
+    %{id: :k006, x: 2, y: 1, opts: [led: :l006]},
+    %{id: :k007, x: 0, y: 2, opts: [led: :l007]},
+    %{id: :k008, x: 1, y: 2, opts: [led: :l008]},
+    %{id: :k009, x: 2, y: 2, opts: [led: :l009]},
+    %{id: :k010, x: 0, y: 3, opts: [led: :l010]},
+    %{id: :k011, x: 1, y: 3, opts: [led: :l011]},
+    %{id: :k012, x: 2, y: 3, opts: [led: :l012]}
+  ]
+
 import_config "#{Mix.env()}.exs"

--- a/config/host/test.exs
+++ b/config/host/test.exs
@@ -1,6 +1,17 @@
 import Config
 
-config :xebow, settings_path: "priv/settings_test"
+config :xebow,
+  settings_path: "priv/settings_test",
+  leds: [
+    %{id: :l1, x: 0, y: 0},
+    %{id: :l2, x: 2, y: 1.5},
+    %{id: :l3, x: 3, y: 3}
+  ],
+  keys: [
+    %{id: :k1, x: 0, y: 0, opts: [led: :l1]},
+    %{id: :k2, x: 2, y: 1.5, opts: [width: 1.5, height: 2, led: :l2]},
+    %{id: :k3, x: 5, y: 0}
+  ]
 
 config :xebow, XebowWeb.Endpoint,
   http: [port: 4002],

--- a/config/host/test.exs
+++ b/config/host/test.exs
@@ -2,15 +2,17 @@ import Config
 
 config :xebow,
   settings_path: "priv/settings_test",
-  leds: [
-    %{id: :l1, x: 0, y: 0},
-    %{id: :l2, x: 2, y: 1.5},
-    %{id: :l3, x: 3, y: 3}
-  ],
-  keys: [
-    %{id: :k1, x: 0, y: 0, opts: [led: :l1]},
-    %{id: :k2, x: 2, y: 1.5, opts: [width: 1.5, height: 2, led: :l2]},
-    %{id: :k3, x: 5, y: 0}
+  layout: [
+    leds: [
+      %{id: :l1, x: 0, y: 0},
+      %{id: :l2, x: 2, y: 1.5},
+      %{id: :l3, x: 3, y: 3}
+    ],
+    keys: [
+      %{id: :k1, x: 0, y: 0, opts: [led: :l1]},
+      %{id: :k2, x: 2, y: 1.5, opts: [width: 1.5, height: 2, led: :l2]},
+      %{id: :k3, x: 5, y: 0}
+    ]
   ]
 
 config :xebow, XebowWeb.Endpoint,

--- a/config/keybow/config.exs
+++ b/config/keybow/config.exs
@@ -84,6 +84,35 @@ config :xebow, XebowWeb.Endpoint,
   url: [host: "xebow.local", port: 80],
   code_reloader: false
 
-config :xebow, settings_path: "/root/settings"
+config :xebow,
+  settings_path: "/root/settings",
+  leds: [
+    %{id: :l001, x: 0, y: 0},
+    %{id: :l002, x: 1, y: 0},
+    %{id: :l003, x: 2, y: 0},
+    %{id: :l004, x: 0, y: 1},
+    %{id: :l005, x: 1, y: 1},
+    %{id: :l006, x: 2, y: 1},
+    %{id: :l007, x: 0, y: 2},
+    %{id: :l008, x: 1, y: 2},
+    %{id: :l009, x: 2, y: 2},
+    %{id: :l010, x: 0, y: 3},
+    %{id: :l011, x: 1, y: 3},
+    %{id: :l012, x: 2, y: 3}
+  ],
+  keys: [
+    %{id: :k001, x: 0, y: 0, opts: [led: :l001]},
+    %{id: :k002, x: 1, y: 0, opts: [led: :l002]},
+    %{id: :k003, x: 2, y: 0, opts: [led: :l003]},
+    %{id: :k004, x: 0, y: 1, opts: [led: :l004]},
+    %{id: :k005, x: 1, y: 1, opts: [led: :l005]},
+    %{id: :k006, x: 2, y: 1, opts: [led: :l006]},
+    %{id: :k007, x: 0, y: 2, opts: [led: :l007]},
+    %{id: :k008, x: 1, y: 2, opts: [led: :l008]},
+    %{id: :k009, x: 2, y: 2, opts: [led: :l009]},
+    %{id: :k010, x: 0, y: 3, opts: [led: :l010]},
+    %{id: :k011, x: 1, y: 3, opts: [led: :l011]},
+    %{id: :k012, x: 2, y: 3, opts: [led: :l012]}
+  ]
 
 import_config "#{Mix.env()}.exs"

--- a/config/keybow/config.exs
+++ b/config/keybow/config.exs
@@ -86,33 +86,35 @@ config :xebow, XebowWeb.Endpoint,
 
 config :xebow,
   settings_path: "/root/settings",
-  leds: [
-    %{id: :l001, x: 0, y: 0},
-    %{id: :l002, x: 1, y: 0},
-    %{id: :l003, x: 2, y: 0},
-    %{id: :l004, x: 0, y: 1},
-    %{id: :l005, x: 1, y: 1},
-    %{id: :l006, x: 2, y: 1},
-    %{id: :l007, x: 0, y: 2},
-    %{id: :l008, x: 1, y: 2},
-    %{id: :l009, x: 2, y: 2},
-    %{id: :l010, x: 0, y: 3},
-    %{id: :l011, x: 1, y: 3},
-    %{id: :l012, x: 2, y: 3}
-  ],
-  keys: [
-    %{id: :k001, x: 0, y: 0, opts: [led: :l001]},
-    %{id: :k002, x: 1, y: 0, opts: [led: :l002]},
-    %{id: :k003, x: 2, y: 0, opts: [led: :l003]},
-    %{id: :k004, x: 0, y: 1, opts: [led: :l004]},
-    %{id: :k005, x: 1, y: 1, opts: [led: :l005]},
-    %{id: :k006, x: 2, y: 1, opts: [led: :l006]},
-    %{id: :k007, x: 0, y: 2, opts: [led: :l007]},
-    %{id: :k008, x: 1, y: 2, opts: [led: :l008]},
-    %{id: :k009, x: 2, y: 2, opts: [led: :l009]},
-    %{id: :k010, x: 0, y: 3, opts: [led: :l010]},
-    %{id: :k011, x: 1, y: 3, opts: [led: :l011]},
-    %{id: :k012, x: 2, y: 3, opts: [led: :l012]}
+  layout: [
+    leds: [
+      %{id: :l001, x: 0, y: 0},
+      %{id: :l002, x: 1, y: 0},
+      %{id: :l003, x: 2, y: 0},
+      %{id: :l004, x: 0, y: 1},
+      %{id: :l005, x: 1, y: 1},
+      %{id: :l006, x: 2, y: 1},
+      %{id: :l007, x: 0, y: 2},
+      %{id: :l008, x: 1, y: 2},
+      %{id: :l009, x: 2, y: 2},
+      %{id: :l010, x: 0, y: 3},
+      %{id: :l011, x: 1, y: 3},
+      %{id: :l012, x: 2, y: 3}
+    ],
+    keys: [
+      %{id: :k001, x: 0, y: 0, opts: [led: :l001]},
+      %{id: :k002, x: 1, y: 0, opts: [led: :l002]},
+      %{id: :k003, x: 2, y: 0, opts: [led: :l003]},
+      %{id: :k004, x: 0, y: 1, opts: [led: :l004]},
+      %{id: :k005, x: 1, y: 1, opts: [led: :l005]},
+      %{id: :k006, x: 2, y: 1, opts: [led: :l006]},
+      %{id: :k007, x: 0, y: 2, opts: [led: :l007]},
+      %{id: :k008, x: 1, y: 2, opts: [led: :l008]},
+      %{id: :k009, x: 2, y: 2, opts: [led: :l009]},
+      %{id: :k010, x: 0, y: 3, opts: [led: :l010]},
+      %{id: :k011, x: 1, y: 3, opts: [led: :l011]},
+      %{id: :k012, x: 2, y: 3, opts: [led: :l012]}
+    ]
   ]
 
 import_config "#{Mix.env()}.exs"

--- a/lib/layout.ex
+++ b/lib/layout.ex
@@ -48,4 +48,24 @@ defmodule Layout do
   @spec key_for_led(layout :: t, LED.id()) :: Key.t() | nil
   def key_for_led(%__MODULE__{} = layout, led_id) when is_atom(led_id),
     do: Map.get(layout.keys_by_leds, led_id)
+
+  @spec get_and_build_leds() :: [LED.t()]
+  def get_and_build_leds() do
+    Application.get_env(:xebow, :leds, [])
+    |> Enum.map(fn %{id: id, x: x, y: y} ->
+      LED.new(id, x, y)
+    end)
+  end
+
+  @spec get_and_build_keys() :: [Key.t()]
+  def get_and_build_keys() do
+    Application.get_env(:xebow, :keys, [])
+    |> Enum.map(fn
+      %{id: id, x: x, y: y, opts: opts} ->
+        Key.new(id, x, y, opts)
+
+      %{id: id, x: x, y: y} ->
+        Key.new(id, x, y)
+    end)
+  end
 end

--- a/lib/layout.ex
+++ b/lib/layout.ex
@@ -49,17 +49,30 @@ defmodule Layout do
   def key_for_led(%__MODULE__{} = layout, led_id) when is_atom(led_id),
     do: Map.get(layout.keys_by_leds, led_id)
 
-  @spec get_and_build_leds() :: [LED.t()]
-  def get_and_build_leds() do
-    Application.get_env(:xebow, :leds, [])
+  @spec load_from_config() :: t
+  def load_from_config do
+    env_layout =
+      case Application.get_env(:xebow, :layout) do
+        nil -> raise "A layout must be defined for the application to function"
+        layout -> layout
+      end
+
+    keys = build_keys(Keyword.get(env_layout, :keys, []))
+    leds = build_leds(Keyword.get(env_layout, :leds, []))
+    new(keys, leds)
+  end
+
+  @spec build_leds([map]) :: [LED.t()]
+  defp build_leds(led_list) do
+    led_list
     |> Enum.map(fn %{id: id, x: x, y: y} ->
       LED.new(id, x, y)
     end)
   end
 
-  @spec get_and_build_keys() :: [Key.t()]
-  def get_and_build_keys() do
-    Application.get_env(:xebow, :keys, [])
+  @spec build_keys([map]) :: [Key.t()]
+  defp build_keys(key_list) do
+    key_list
     |> Enum.map(fn
       %{id: id, x: x, y: y, opts: opts} ->
         Key.new(id, x, y, opts)

--- a/lib/xebow.ex
+++ b/lib/xebow.ex
@@ -9,9 +9,7 @@ defmodule Xebow do
 
   require Logger
 
-  @leds Layout.get_and_build_leds()
-  @keys Layout.get_and_build_keys()
-  @layout Layout.new(@keys, @leds)
+  @layout Layout.load_from_config()
 
   @spec layout() :: Layout.t()
   def layout, do: @layout
@@ -209,7 +207,8 @@ defmodule Xebow do
   end
 
   defp initialize_animation(animation_type) do
-    Animation.new(animation_type, @leds)
+    leds = Layout.leds(@layout)
+    Animation.new(animation_type, leds)
   end
 
   defp update_state_with_animation_types(state, animation_types) do

--- a/lib/xebow.ex
+++ b/lib/xebow.ex
@@ -4,42 +4,13 @@ defmodule Xebow do
   Keybow kit.
   """
 
-  alias Layout.{Key, LED}
   alias RGBMatrix.{Animation, Engine}
   alias Xebow.Settings
 
   require Logger
 
-  @leds [
-    LED.new(:l001, 0, 0),
-    LED.new(:l002, 1, 0),
-    LED.new(:l003, 2, 0),
-    LED.new(:l004, 0, 1),
-    LED.new(:l005, 1, 1),
-    LED.new(:l006, 2, 1),
-    LED.new(:l007, 0, 2),
-    LED.new(:l008, 1, 2),
-    LED.new(:l009, 2, 2),
-    LED.new(:l010, 0, 3),
-    LED.new(:l011, 1, 3),
-    LED.new(:l012, 2, 3)
-  ]
-
-  @keys [
-    Key.new(:k001, 0, 0, led: :l001),
-    Key.new(:k002, 1, 0, led: :l002),
-    Key.new(:k003, 2, 0, led: :l003),
-    Key.new(:k004, 0, 1, led: :l004),
-    Key.new(:k005, 1, 1, led: :l005),
-    Key.new(:k006, 2, 1, led: :l006),
-    Key.new(:k007, 0, 2, led: :l007),
-    Key.new(:k008, 1, 2, led: :l008),
-    Key.new(:k009, 2, 2, led: :l009),
-    Key.new(:k010, 0, 3, led: :l010),
-    Key.new(:k011, 1, 3, led: :l011),
-    Key.new(:k012, 2, 3, led: :l012)
-  ]
-
+  @leds Layout.get_and_build_leds()
+  @keys Layout.get_and_build_keys()
   @layout Layout.new(@keys, @leds)
 
   @spec layout() :: Layout.t()

--- a/test/layout/key_test.exs
+++ b/test/layout/key_test.exs
@@ -1,0 +1,27 @@
+defmodule LayoutKeyTest do
+  use ExUnit.Case
+
+  alias Layout.Key
+
+  test "new/3 creates a %Key{} struct with default :width, :height, and :led" do
+    assert Key.new(:a, 0, 0) == %Key{id: :a, x: 0, y: 0, width: 1, height: 1, led: nil}
+    assert Key.new(:b, 1, 2) == %Key{id: :b, x: 1, y: 2, width: 1, height: 1, led: nil}
+  end
+
+  test "new/4 allows setting :width, :height, and :led" do
+    assert Key.new(:a, 1, 2, width: 3, height: 4, led: :b) ==
+             %Key{id: :a, x: 1, y: 2, width: 3, height: 4, led: :b}
+  end
+
+  test "new/4 allows setting :led only" do
+    assert Key.new(:b, 2, 4, led: :c) ==
+             %Key{id: :b, x: 2, y: 4, led: :c, width: 1, height: 1}
+  end
+
+  test "new/4 allows setting :width or :height only" do
+    assert Key.new(:l001, 1, 1, width: 1.5) ==
+             %Key{id: :l001, x: 1, y: 1, width: 1.5, height: 1, led: nil}
+    assert Key.new(:l002, 2, 3, height: 2) ==
+             %Key{id: :l002, x: 2, y: 3, width: 1, height: 2, led: nil}
+  end
+end

--- a/test/layout/key_test.exs
+++ b/test/layout/key_test.exs
@@ -21,6 +21,7 @@ defmodule LayoutKeyTest do
   test "new/4 allows setting :width or :height only" do
     assert Key.new(:l001, 1, 1, width: 1.5) ==
              %Key{id: :l001, x: 1, y: 1, width: 1.5, height: 1, led: nil}
+
     assert Key.new(:l002, 2, 3, height: 2) ==
              %Key{id: :l002, x: 2, y: 3, width: 1, height: 2, led: nil}
   end

--- a/test/layout/led_test.exs
+++ b/test/layout/led_test.exs
@@ -1,0 +1,10 @@
+defmodule LayoutLEDTest do
+  use ExUnit.Case
+
+  alias Layout.LED
+
+  test "new/3 takes 3 arguments and creates a %Layout.LED{} struct" do
+    assert LED.new(:l1, 0, 0) == %LED{id: :l1, x: 0, y: 0}
+    assert LED.new(:l2, 1, 3) == %LED{id: :l2, x: 1, y: 3}
+  end
+end

--- a/test/layout_test.exs
+++ b/test/layout_test.exs
@@ -1,0 +1,117 @@
+defmodule LayoutTest do
+  use ExUnit.Case
+
+  alias Layout.{Key, LED}
+
+  # The following tests use parameters defined in `config/host/test.exs`
+  #
+  # The following keys are defined for the test environment:
+  # keys: [
+  #   %{id: :k1, x: 0, y: 0, opts: [led: :l1]},
+  #   %{id: :k2, x: 2, y: 1.5, opts: [width: 1.5, height: 2, led: :l2]},
+  #   %{id: :k3, x: 5, y: 0}
+  # ]
+  #
+  # The following LEDs are defined for the test environment:
+  # leds: [
+  #   %{id: :l1, x: 0, y: 0},
+  #   %{id: :l2, x: 2, y: 1.5},
+  #   %{id: :l3, x: 3, y: 3}
+  # ]
+  test "Layout.get_and_build_keys/0 returns a list of keys built from application config" do
+    assert Layout.get_and_build_keys() ==
+             [
+               %Key{height: 1, id: :k1, led: :l1, width: 1, x: 0, y: 0},
+               %Key{height: 2, id: :k2, led: :l2, width: 1.5, x: 2, y: 1.5},
+               %Key{height: 1, id: :k3, led: nil, width: 1, x: 5, y: 0}
+             ]
+  end
+
+  test "Layout.get_and_build_leds/0 returns a list of LEDs built from application config" do
+    assert Layout.get_and_build_leds() ==
+             [
+               %LED{id: :l1, x: 0, y: 0},
+               %LED{id: :l2, x: 2, y: 1.5},
+               %LED{id: :l3, x: 3, y: 3}
+             ]
+  end
+
+  defp add_keys(_context) do
+    [keys: Layout.get_and_build_keys()]
+  end
+
+  defp add_leds(_context) do
+    [leds: Layout.get_and_build_leds()]
+  end
+
+  setup [:add_keys, :add_leds]
+
+  test "new/1 takes only a list of keys and returns a %Layout{} struct" do
+    keys = [Key.new(:k, 0, 0)]
+
+    assert Layout.new(keys) == %Layout{
+             keys: [%Key{height: 1, id: :k, led: nil, width: 1, x: 0, y: 0}],
+             keys_by_leds: %{},
+             leds: [],
+             leds_by_keys: %{}
+           }
+  end
+
+  test "new/2 takes a list of keys and a list of LEDs and returns a %Layout{} struct",
+       %{keys: keys, leds: leds} do
+    assert Layout.new(keys, leds) == %Layout{
+             keys: [
+               %Key{height: 1, id: :k1, led: :l1, width: 1, x: 0, y: 0},
+               %Key{height: 2, id: :k2, led: :l2, width: 1.5, x: 2, y: 1.5},
+               %Key{height: 1, id: :k3, led: nil, width: 1, x: 5, y: 0}
+             ],
+             keys_by_leds: %{
+               l1: %Key{height: 1, id: :k1, led: :l1, width: 1, x: 0, y: 0},
+               l2: %Key{height: 2, id: :k2, led: :l2, width: 1.5, x: 2, y: 1.5}
+             },
+             leds: [
+               %LED{id: :l1, x: 0, y: 0},
+               %LED{id: :l2, x: 2, y: 1.5},
+               %LED{id: :l3, x: 3, y: 3}
+             ],
+             leds_by_keys: %{
+               k1: %LED{id: :l1, x: 0, y: 0},
+               k2: %LED{id: :l2, x: 2, y: 1.5}
+             }
+           }
+  end
+
+  defp add_layout(context) do
+    [layout: Layout.new(context.keys, context.leds)]
+  end
+
+  setup :add_layout
+
+  test "keys/1 takes a layout and returns its list of keys",
+       %{keys: keys, layout: layout} do
+    assert Layout.keys(layout) == keys
+    assert Layout.keys(layout) == layout.keys
+  end
+
+  test "leds/1 takes a layout and returns its list of LEDs",
+       %{layout: layout, leds: leds} do
+    assert Layout.leds(layout) == leds
+    assert Layout.leds(layout) == layout.leds
+  end
+
+  test "led_for_key/2 takes a layout and a key id and returns the corresponding LED or nil",
+       %{layout: layout, leds: leds} do
+    led_for_k1 = Enum.find(leds, fn %{id: id} -> id == :l1 end)
+    led_for_k3 = nil
+    assert Layout.led_for_key(layout, :k1) == led_for_k1
+    assert Layout.led_for_key(layout, :k3) == led_for_k3
+  end
+
+  test "key_for_led/2 takes a layout and a LED id and returns the corresponding key or nil",
+       %{keys: keys, layout: layout} do
+    key_for_l1 = Enum.find(keys, fn %{led: led} -> led == :l1 end)
+    key_for_l3 = nil
+    assert Layout.key_for_led(layout, :l1) == key_for_l1
+    assert Layout.key_for_led(layout, :l3) == key_for_l3
+  end
+end


### PR DESCRIPTION
This moves definition of keys and LEDs out of modules and into the corresponding config file for a specific host or environment. Environment-specific definitions take precedence because of the structure of the config files (config -> host -> env).

Because I had to touch the `Layout` module, I added tests.