### PR TITLE
Add Engine tests back

### DIFF
--- a/lib/rgb_matrix/engine.ex
+++ b/lib/rgb_matrix/engine.ex
@@ -9,8 +9,7 @@ defmodule RGBMatrix.Engine do
   alias Layout.LED
   alias RGBMatrix.Animation
 
-  @type frame :: %{led_id => RGBMatrix.any_color_model()}
-  @type led_id :: atom
+  @type frame :: %{LED.id() => RGBMatrix.any_color_model()}
 
   defmodule State do
     @moduledoc false

--- a/lib/xebow/application.ex
+++ b/lib/xebow/application.ex
@@ -7,8 +7,6 @@ defmodule Xebow.Application do
 
   alias Xebow.Settings
 
-  @leds Xebow.layout() |> Layout.leds()
-
   if Mix.target() == :host do
     defp maybe_validate_firmware,
       do: nil
@@ -31,7 +29,7 @@ defmodule Xebow.Application do
         # Starts a worker by calling: Xebow.Worker.start_link(arg)
         # {Xebow.Worker, arg},
         # Engine must be started before Xebow
-        {RGBMatrix.Engine, @leds},
+        RGBMatrix.Engine,
         Xebow,
         # Phoenix:
         XebowWeb.Telemetry,

--- a/test/rgb_matrix/engine_test.exs
+++ b/test/rgb_matrix/engine_test.exs
@@ -50,29 +50,16 @@ defmodule RGBMatrix.EngineTest do
     end
   end
 
-  describe "can unregister paintables" do
-    test "that have been registered", %{
-      frame: frame,
-      paint_fn: paint_fn
-    } do
-      {:ok, ^paint_fn, _frame} = Engine.register_paintable(paint_fn)
+  test "unregistering paintables is idempotent", %{
+    frame: frame,
+    paint_fn: paint_fn
+  } do
+    {:ok, ^paint_fn, _frame} = Engine.register_paintable(paint_fn)
 
-      assert Engine.unregister_paintable(paint_fn) == :ok
-      assert maybe_receive_some_frames(frame, 6)
-    end
-
-    test "and will ignore invalid input", %{
-      frame: frame,
-      paint_fn: paint_fn
-    } do
-      {:ok, ^paint_fn, _frame} = Engine.register_paintable(paint_fn)
-      fake_paint_fn = "NE!"
-      unused_paint_fn = fn _frame -> :ok end
-
-      assert Engine.unregister_paintable(fake_paint_fn) == :ok
-      assert Engine.unregister_paintable(unused_paint_fn) == :ok
-      assert_receive {:frame, ^frame}
-    end
+    assert Engine.unregister_paintable(paint_fn) == :ok
+    assert Engine.unregister_paintable(paint_fn) == :ok
+    assert maybe_receive_some_frames(frame, 6)
+    refute_receive {:frame, ^frame}
   end
 
   # Creates a module which renders the test frame


### PR DESCRIPTION
This adds several tests for the engine back in.

Unregistration tests were slightly tricky because of the GenServer. There is a slight chance that multiple `:render` messages could be sent to the engine between the time `unregister_paintable/1` is called and the time the paintable is actually removed from the engine. This means that possibly more than one frame could still get rendered using a paintable which has been requested for unregistration. This is really only an issue I've seen if an animation is set to render with a 0 delay, though.

I would like to make sure we're all okay with the method I used to test, which accounts for this multiple frame possibility. See `engine_test.exs` at [L229 for usage](https://github.com/ElixirSeattle/xebow/blob/19d16a8bca18e0225b6df9621094c923ab8c20a0/test/rgb_matrix/engine_test.exs#L229) and [L88 for method](https://github.com/ElixirSeattle/xebow/blob/19d16a8bca18e0225b6df9621094c923ab8c20a0/test/rgb_matrix/engine_test.exs#L88).

I didn't add tests for configurables because I think those would be better removed from the engine to try and keep it as streamlined as possible. Configurables only get touched when the animation changes, which is more of a Xebow application concern at the moment.

This also removes `LEDs` from the Engine, so it no longer needs to be started up with the list of LEDs.

Resolves #69 