### PR TITLE
Add nodejs to asdf .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 elixir 1.10.3-otp-23
 erlang 23.0.2
+nodejs 12.16.3


### PR DESCRIPTION
Since Node is a dependency for building this project it makes sense to include it in the asdf .tool-versions so that way we can control the exact node version this uses.

The same command `asdf install` will install elixir, erlang and node now.

I just picked a recent version of node, I'm not sure what exact version you might want.