### PR TITLE
Move "configurables" from Engine to Xebow

### DIFF
--- a/lib/rgb_matrix/animation.ex
+++ b/lib/rgb_matrix/animation.ex
@@ -100,18 +100,18 @@ defmodule RGBMatrix.Animation do
   @doc """
   Gets the current configuration and the configuration schema from an animation.
   """
-  @spec get_config(animation :: t) :: {struct, keyword(struct)}
+  @spec get_config(animation :: t) :: {Config.t(), Config.schema()}
   def get_config(animation) do
     %config_module{} = config = animation.config
-    config_schema = config_module.schema()
+    schema = config_module.schema()
 
-    {config, config_schema}
+    {config, schema}
   end
 
   @doc """
   Updates the configuration of an animation and returns the updated animation.
   """
-  @spec update_config(animation :: t, params :: map) :: t
+  @spec update_config(animation :: t, params :: Config.update_params()) :: t
   def update_config(animation, params) do
     %config_module{} = config = animation.config
     config = config_module.update(config, params)

--- a/lib/rgb_matrix/animation/config.ex
+++ b/lib/rgb_matrix/animation/config.ex
@@ -19,9 +19,9 @@ defmodule RGBMatrix.Animation.Config do
       RGBMatrix.Animation.HueWave.Config
       RGBMatrix.Animation.SolidReactive.Config
 
-  Configs should not be accessed or modified directly. Use the functions
-  `Xebow.get_animation_config/0` and `Xebow.update_animation_config/1` for
-  access and modification.
+  Configs should not be accessed or modified directly in an Animation module.
+  Use the functions `Xebow.get_animation_config/0` and
+  `Xebow.update_animation_config/1` for access and modification.
   """
   @type t :: struct
 
@@ -40,7 +40,7 @@ defmodule RGBMatrix.Animation.Config do
   The documentation is optional and will be initialized to an empty list if
   omitted.
   """
-  @type config_schema :: keyword(FieldType.t())
+  @type schema :: keyword(FieldType.t())
 
   @typedoc """
   A map used during creation of an `Animation.<type>.Config`.
@@ -70,7 +70,7 @@ defmodule RGBMatrix.Animation.Config do
   """
   @type update_params :: %{(atom | String.t()) => any}
 
-  @callback schema() :: config_schema
+  @callback schema() :: schema
   @callback new(%{optional(atom) => FieldType.value()}) :: t
   @callback update(t, %{optional(atom | String.t()) => any}) :: t
 
@@ -143,7 +143,7 @@ defmodule RGBMatrix.Animation.Config do
   """
   @spec new_config(
           module :: module,
-          schema :: config_schema,
+          schema :: schema,
           params :: creation_params
         ) :: t
   def new_config(module, schema, params) do
@@ -178,7 +178,7 @@ defmodule RGBMatrix.Animation.Config do
   """
   @spec update_config(
           config :: t,
-          schema :: config_schema,
+          schema :: schema,
           params :: update_params
         ) :: t
   def update_config(config, schema, params) do
@@ -191,7 +191,7 @@ defmodule RGBMatrix.Animation.Config do
   @spec cast_and_update_field(
           param :: {atom | String.t(), any},
           config :: t,
-          schema :: config_schema
+          schema :: schema
         ) :: t
   defp cast_and_update_field({key, value} = _param, config, schema) do
     with {:ok, key} <- create_atom_key(key),
@@ -232,7 +232,7 @@ defmodule RGBMatrix.Animation.Config do
       {:error, :undefined_field}
   end
 
-  @spec fetch_type_from_schema(config_schema, atom) ::
+  @spec fetch_type_from_schema(schema, atom) ::
           {:ok, FieldType.t()} | {:error, :undefined_field}
   defp fetch_type_from_schema(schema, key) do
     case Keyword.fetch(schema, key) do

--- a/lib/rgb_matrix/animation/config.ex
+++ b/lib/rgb_matrix/animation/config.ex
@@ -19,9 +19,9 @@ defmodule RGBMatrix.Animation.Config do
       RGBMatrix.Animation.HueWave.Config
       RGBMatrix.Animation.SolidReactive.Config
 
-  Configs should not be accessed or modified directly in an Animation module.
-  Use the functions `Xebow.get_animation_config/0` and
-  `Xebow.update_animation_config/1` for access and modification.
+  Configs should not be accessed or modified directly. Use the functions
+  `Xebow.get_animation_config/0` and `Xebow.update_animation_config/1` for
+  access and modification.
   """
   @type t :: struct
 

--- a/lib/rgb_matrix/engine.ex
+++ b/lib/rgb_matrix/engine.ex
@@ -13,7 +13,7 @@ defmodule RGBMatrix.Engine do
 
   defmodule State do
     @moduledoc false
-    defstruct [:leds, :animation, :paintables, :last_frame, :timer]
+    defstruct [:animation, :paintables, :last_frame, :timer]
   end
 
   # Client
@@ -72,8 +72,7 @@ defmodule RGBMatrix.Engine do
   @impl GenServer
   def init(_args) do
     state = %State{
-      leds: leds,
-      last_frame: frame,
+      last_frame: %{},
       paintables: MapSet.new()
     }
 

--- a/lib/rgb_matrix/engine.ex
+++ b/lib/rgb_matrix/engine.ex
@@ -13,7 +13,7 @@ defmodule RGBMatrix.Engine do
 
   defmodule State do
     @moduledoc false
-    defstruct [:animation, :paintables, :last_frame, :timer, :configurables]
+    defstruct [:leds, :animation, :paintables, :last_frame, :timer]
   end
 
   # Client
@@ -67,37 +67,14 @@ defmodule RGBMatrix.Engine do
     GenServer.cast(__MODULE__, {:interact, led})
   end
 
-  @doc """
-  Register a config function for the engine to send animation configuration to
-  when it changes.
-
-  This function is idempotent.
-  """
-  @spec register_configurable(config_fn :: function) :: {:ok, function}
-  def register_configurable(config_fn) do
-    :ok = GenServer.call(__MODULE__, {:register_configurable, config_fn})
-    {:ok, config_fn}
-  end
-
-  @doc """
-  Unregister a config function so the engine no longer sends animation
-  configuration to it.
-
-  This function is idempotent.
-  """
-  @spec unregister_configurable(config_fn :: function) :: :ok
-  def unregister_configurable(config_fn) do
-    GenServer.call(__MODULE__, {:unregister_configurable, config_fn})
-  end
-
   # Server
 
   @impl GenServer
   def init(_args) do
     state = %State{
-      last_frame: %{},
-      paintables: MapSet.new(),
-      configurables: MapSet.new()
+      leds: leds,
+      last_frame: frame,
+      paintables: MapSet.new()
     }
 
     {:ok, state}
@@ -172,7 +149,6 @@ defmodule RGBMatrix.Engine do
     state =
       %State{state | animation: animation, last_frame: %{}}
       |> schedule_next_render(0)
-      |> inform_configurables()
 
     {:noreply, state}
   end
@@ -198,38 +174,5 @@ defmodule RGBMatrix.Engine do
   def handle_call({:unregister_paintable, key}, _from, state) do
     state = remove_paintable(key, state)
     {:reply, :ok, state}
-  end
-
-  @impl GenServer
-  def handle_call({:register_configurable, config_fn}, _from, state) do
-    state = add_configurable(config_fn, state)
-    {:reply, :ok, state}
-  end
-
-  @impl GenServer
-  def handle_call({:unregister_configurable, config_fn}, _from, state) do
-    state = remove_configurable(config_fn, state)
-    {:reply, :ok, state}
-  end
-
-  defp add_configurable(config_fn, state) do
-    configurables = MapSet.put(state.configurables, config_fn)
-    %State{state | configurables: configurables}
-  end
-
-  defp remove_configurable(config_fn, state) do
-    configurables = MapSet.delete(state.configurables, config_fn)
-    %State{state | configurables: configurables}
-  end
-
-  defp inform_configurables(state) do
-    config = Animation.get_config(state.animation)
-
-    Enum.reduce(state.configurables, state, fn config_fn, state ->
-      case config_fn.(config) do
-        :ok -> state
-        :unregister -> remove_configurable(config_fn, state)
-      end
-    end)
   end
 end

--- a/lib/xebow_web/live/matrix_live.ex
+++ b/lib/xebow_web/live/matrix_live.ex
@@ -97,7 +97,7 @@ defmodule XebowWeb.MatrixLive do
   @impl Phoenix.LiveView
   def terminate(_reason, socket) do
     Engine.unregister_paintable(socket.assigns.paint_fn)
-    Engine.unregister_configurable(socket.assigns.config_fn)
+    Xebow.unregister_configurable(socket.assigns.config_fn)
   end
 
   defp register_with_engine! do
@@ -114,7 +114,7 @@ defmodule XebowWeb.MatrixLive do
       end)
 
     {:ok, config_fn} =
-      Engine.register_configurable(fn config ->
+      Xebow.register_configurable(fn config ->
         if Process.alive?(pid) do
           send(pid, {:render_config, config})
           :ok

--- a/test/xebow_test.exs
+++ b/test/xebow_test.exs
@@ -4,8 +4,8 @@ defmodule XebowTest do
   alias RGBMatrix.Animation
 
   setup_all [
-    :create_mock_animations,
-    :create_single_animation,
+    :create_mock_animation_list,
+    :create_single_animation_list,
     :create_single_schema
   ]
 
@@ -15,10 +15,10 @@ defmodule XebowTest do
 
   describe "can get and set active animation types" do
     test "with a list of animation modules", %{
-      mock_animations: mock_animations
+      mock_animation_list: mock_animation_list
     } do
-      assert Xebow.set_active_animation_types(mock_animations) == :ok
-      assert Xebow.get_active_animation_types() == mock_animations
+      assert Xebow.set_active_animation_types(mock_animation_list) == :ok
+      assert Xebow.get_active_animation_types() == mock_animation_list
     end
 
     test "with an empty list" do
@@ -28,8 +28,8 @@ defmodule XebowTest do
   end
 
   describe "animations can be cycled" do
-    setup %{mock_animations: mock_animations} do
-      Xebow.set_active_animation_types(mock_animations)
+    setup %{mock_animation_list: mock_animation_list} do
+      Xebow.set_active_animation_types(mock_animation_list)
     end
 
     test "forward" do
@@ -40,10 +40,10 @@ defmodule XebowTest do
       assert Xebow.previous_animation() == :ok
     end
 
-    test "through the entire list, repeatedly", %{
-      mock_animations: mock_animations
+    test "through the list, which wraps in both directions", %{
+      mock_animation_list: mock_animation_list
     } do
-      double_count = length(mock_animations) * 2
+      double_count = length(mock_animation_list) * 2
 
       for _ <- 1..double_count do
         assert Xebow.next_animation() == :ok
@@ -55,16 +55,15 @@ defmodule XebowTest do
     end
   end
 
-  setup %{single_animation: single_animation} do
-    Xebow.set_active_animation_types(single_animation)
+  setup %{single_animation_list: single_animation_list} do
+    Xebow.set_active_animation_types(single_animation_list)
   end
 
   describe "can get the config and schema" do
     test "of the current active animation", %{
-      single_animation: single_animation,
+      single_animation_list: [animation_module],
       single_schema: single_schema
     } do
-      [animation_module] = single_animation
       config_module = Module.concat(animation_module, "Config")
 
       assert {%^config_module{}, ^single_schema} = Xebow.get_animation_config()
@@ -160,21 +159,21 @@ defmodule XebowTest do
     [config_fn: config_fn]
   end
 
-  defp create_mock_animations(_context) do
-    mock_animations = [
+  defp create_mock_animation_list(_context) do
+    mock_animation_list = [
       Type1,
       Type2,
       Type3
     ]
 
-    Enum.each(mock_animations, fn module_name ->
+    Enum.each(mock_animation_list, fn module_name ->
       Module.create(module_name, mock_animation_module(module_name), __ENV__)
     end)
 
-    [mock_animations: mock_animations]
+    [mock_animation_list: mock_animation_list]
   end
 
-  defp create_single_animation(_context), do: [single_animation: [Type1]]
+  defp create_single_animation_list(_context), do: [single_animation_list: [Type1]]
 
   defp create_single_schema(_context) do
     schema = [

--- a/test/xebow_test.exs
+++ b/test/xebow_test.exs
@@ -3,31 +3,223 @@ defmodule XebowTest do
 
   alias RGBMatrix.Animation
 
-  defmodule MockAnimations.Type1 do
-    use Animation
-
-    @impl Animation
-    def new(_leds, _config) do
-      nil
-    end
-
-    @impl Animation
-    def render(_state, _config) do
-      {1000, [], nil}
-    end
-  end
+  setup_all [
+    :create_mock_animations,
+    :create_single_animation,
+    :create_single_schema
+  ]
 
   test "has layout" do
     assert %Layout{} = Xebow.layout()
   end
 
-  test "can get and set active animation types" do
-    animation_types = [MockAnimations.Type1]
+  describe "can get and set active animation types" do
+    test "with a list of animation modules", %{
+      mock_animations: mock_animations
+    } do
+      assert Xebow.set_active_animation_types(mock_animations) == :ok
+      assert Xebow.get_active_animation_types() == mock_animations
+    end
 
-    assert Xebow.get_active_animation_types() != animation_types
+    test "with an empty list" do
+      assert Xebow.set_active_animation_types([]) == :ok
+      assert Xebow.get_active_animation_types() == []
+    end
+  end
 
-    Xebow.set_active_animation_types(animation_types)
+  describe "animations can be cycled" do
+    setup %{mock_animations: mock_animations} do
+      Xebow.set_active_animation_types(mock_animations)
+    end
 
-    assert Xebow.get_active_animation_types() == animation_types
+    test "forward" do
+      assert Xebow.next_animation() == :ok
+    end
+
+    test "backward" do
+      assert Xebow.previous_animation() == :ok
+    end
+
+    test "through the entire list, repeatedly", %{
+      mock_animations: mock_animations
+    } do
+      double_count = length(mock_animations) * 2
+
+      for _ <- 1..double_count do
+        assert Xebow.next_animation() == :ok
+      end
+
+      for _ <- 1..double_count do
+        assert Xebow.previous_animation() == :ok
+      end
+    end
+  end
+
+  setup %{single_animation: single_animation} do
+    Xebow.set_active_animation_types(single_animation)
+  end
+
+  describe "can get the config and schema" do
+    test "of the current active animation", %{
+      single_animation: single_animation,
+      single_schema: single_schema
+    } do
+      [animation_module] = single_animation
+      config_module = Module.concat(animation_module, "Config")
+
+      assert {%^config_module{}, ^single_schema} = Xebow.get_animation_config()
+    end
+
+    test "or nil when no animations active" do
+      Xebow.set_active_animation_types([])
+
+      assert Xebow.get_animation_config() == nil
+    end
+  end
+
+  test "config of the current animation can be updated", %{} do
+    single_config = Xebow.get_animation_config()
+    update_params = %{test_field: :b}
+
+    assert Xebow.update_animation_config(update_params) == :ok
+    refute Xebow.get_animation_config() == single_config
+
+    {config, _schema} = Xebow.get_animation_config()
+
+    assert config.test_field == :b
+  end
+
+  describe "configurables" do
+    setup [:create_config_fn, :create_unregister_config_fn]
+
+    test "can be registered, which is idempotent", %{
+      config_fn: config_fn
+    } do
+      assert Xebow.register_configurable(config_fn) == {:ok, config_fn}
+      assert Xebow.register_configurable(config_fn) == {:ok, config_fn}
+
+      Xebow.next_animation()
+      config = Xebow.get_animation_config()
+
+      assert_receive {:config, ^config}
+      refute_receive {:config, ^config}
+    end
+
+    test "can be unregistered, which is idempotent", %{
+      config_fn: config_fn
+    } do
+      Xebow.register_configurable(config_fn)
+
+      assert Xebow.unregister_configurable(config_fn) == :ok
+      assert Xebow.unregister_configurable(config_fn) == :ok
+
+      Xebow.previous_animation()
+      config = Xebow.get_animation_config()
+
+      refute_receive {:config, ^config}
+    end
+
+    test "are called when switching animations", %{
+      config_fn: config_fn
+    } do
+      Xebow.register_configurable(config_fn)
+
+      Xebow.next_animation()
+      config = Xebow.get_animation_config()
+      assert_receive {:config, ^config}
+    end
+
+    test "can return :unregister to unregister themselves", %{
+      unregister_config_fn: unregister_config_fn,
+      unregister_message: unregister_message
+    } do
+      assert Xebow.register_configurable(unregister_config_fn) == {:ok, unregister_config_fn}
+
+      Xebow.next_animation()
+      assert_receive ^unregister_message
+
+      Xebow.next_animation()
+      refute_receive ^unregister_message
+    end
+  end
+
+  # This must be added in `setup` so the pid belongs to the test process.
+  defp create_config_fn(_context) do
+    pid = self()
+
+    config_fn = fn config ->
+      send(pid, {:config, config})
+      :ok
+    end
+
+    [config_fn: config_fn]
+  end
+
+  defp create_unregister_config_fn(_context) do
+    pid = self()
+    unregister_message = {:config, "unregister"}
+
+    unregister_config_fn = fn _config ->
+      send(pid, unregister_message)
+      :unregister
+    end
+
+    [unregister_config_fn: unregister_config_fn, unregister_message: unregister_message]
+  end
+
+  defp create_mock_animations(_context) do
+    mock_animations = [
+      Type1,
+      Type2,
+      Type3
+    ]
+
+    Enum.each(mock_animations, fn module_name ->
+      Module.create(module_name, mock_animation_module(module_name), __ENV__)
+    end)
+
+    [mock_animations: mock_animations]
+  end
+
+  defp create_single_animation(_context), do: [single_animation: [Type1]]
+
+  defp create_single_schema(_context) do
+    schema = [
+      test_field: %RGBMatrix.Animation.Config.FieldType.Option{
+        options: [:a, :b],
+        default: :a,
+        doc: []
+      }
+    ]
+
+    [single_schema: schema]
+  end
+
+  defp mock_animation_module(Type1) do
+    quote do
+      use Animation
+
+      field :test_field, :option,
+        options: ~w(a b)a,
+        default: :a
+
+      @impl true
+      def new(_leds, _config), do: nil
+
+      @impl true
+      def render(_state, _config), do: {1000, %{}, nil}
+    end
+  end
+
+  defp mock_animation_module(_) do
+    quote do
+      use Animation
+
+      @impl true
+      def new(_leds, _config), do: nil
+
+      @impl true
+      def render(_state, _config), do: {1000, %{}, nil}
+    end
   end
 end


### PR DESCRIPTION
This aims to clean up the Engine a bit more by moving the configurables into Xebow. Because Xebow is the general place where configuration happens, it seemed the most logical place to put it for now.

Configurables seem... strange. They only get used in the Live View to make sure the display elements are consistent with the current configuration state. I want there to be a better way to push those updates down to the Live View, but I haven't taken a closer look at it, yet.

Anyway, because I had to work in the Xebow section, I added a good number of tests to it. Tried to cover almost everything.

Updated a bit of typing and documentation in `Animation` and `Config`, but it's minor.